### PR TITLE
Fix length calculation for ByteStringObjects with certain sizes

### DIFF
--- a/src/LengthCalculator.php
+++ b/src/LengthCalculator.php
@@ -37,15 +37,15 @@ final class LengthCalculator
     private static function computeLength(int $length): array
     {
         switch (true) {
-            case $length < 24:
+            case $length <= 23:
                 return [$length, null];
-            case $length < 0xFF:
+            case $length <= 0xFF:
                 return [24, chr($length)];
-            case $length < 0xFFFF:
+            case $length <= 0xFFFF:
                 return [25, self::hex2bin(static::fixHexLength(Utils::intToHex($length)))];
-            case $length < 0xFFFFFFFF:
+            case $length <= 0xFFFFFFFF:
                 return [26, self::hex2bin(static::fixHexLength(Utils::intToHex($length)))];
-            case BigInteger::of($length)->isLessThan(BigInteger::fromBase('FFFFFFFFFFFFFFFF', 16)):
+            case BigInteger::of($length)->isLessThanOrEqualTo(BigInteger::fromBase('FFFFFFFFFFFFFFFF', 16)):
                 return [27, self::hex2bin(static::fixHexLength(Utils::intToHex($length)))];
             default:
                 return [31, null];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests added   |  <!--highly recommended for new features-->
| Doc PR        |  <!--highly recommended for new features-->

Before this PR, the library encoded byte strings with a length of 0xFF, 0xFFFF, 0xFFFFFF etc. to the wrong CBOR tag. (e.g. it used 0x59 for length == 0xFF) which resulted in invalid CBOR output.