### PR TITLE
Allow brick/math 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "brick/math": "^0.9|^0.10|^0.11",
+        "brick/math": "^0.9|^0.10|^0.11|^0.12",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
The breaking changes of brick/math 0.12 does not affect this library, so allowing this should be safe.

- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
