### PR TITLE
Fix object creation with correct precision type

### DIFF
--- a/src/OtherObject/SinglePrecisionFloatObject.php
+++ b/src/OtherObject/SinglePrecisionFloatObject.php
@@ -30,7 +30,7 @@ final class SinglePrecisionFloatObject extends Base
             ))(),
         };
 
-        return new self(self::OBJECT_DOUBLE_PRECISION_FLOAT, $value);
+        return new self(self::OBJECT_SINGLE_PRECISION_FLOAT, $value);
     }
 
     public static function createFromLoadedData(int $additionalInformation, ?string $data): Base


### PR DESCRIPTION
Previously, the method incorrectly created an object with double precision instead of single precision. This commit corrects the precision type to ensure single-precision float objects are created as intended.

Target branch: 4.0.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
