### PR TITLE
Fix CI: ECS import ordering and exported files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /.gitignore export-ignore
 /.gitsplit.yml export-ignore
 /castor.php export-ignore
+/.agents export-ignore

--- a/tests/BigFloatTagTest.php
+++ b/tests/BigFloatTagTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace CBOR\Test;
 
 use CBOR\Tag\BigFloatTag;
-use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\Test;
 use function extension_loaded;
 use const INF;
+use InvalidArgumentException;
 use const NAN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Test cases for BigFloatTag (Tag 5)

--- a/tests/DecimalFractionTagTest.php
+++ b/tests/DecimalFractionTagTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace CBOR\Test;
 
 use CBOR\Tag\DecimalFractionTag;
-use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\Test;
 use function extension_loaded;
 use const INF;
+use InvalidArgumentException;
 use const NAN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Test cases for DecimalFractionTag (Tag 4)

--- a/tests/DoublePrecisionFloatTest.php
+++ b/tests/DoublePrecisionFloatTest.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace CBOR\Test;
 
 use CBOR\OtherObject\DoublePrecisionFloatObject;
-use PHPUnit\Framework\Attributes\Test;
+use const INF;
 use function is_float;
 use function is_int;
-use const INF;
 use const M_E;
 use const M_PI;
 use const NAN;
 use const PHP_FLOAT_MAX;
 use const PHP_FLOAT_MIN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal

--- a/tests/FloatRFC8949Test.php
+++ b/tests/FloatRFC8949Test.php
@@ -7,9 +7,9 @@ namespace CBOR\Test;
 use CBOR\OtherObject\DoublePrecisionFloatObject;
 use CBOR\OtherObject\HalfPrecisionFloatObject;
 use CBOR\OtherObject\SinglePrecisionFloatObject;
-use PHPUnit\Framework\Attributes\Test;
 use const INF;
 use const NAN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Test cases based on RFC 8949 (CBOR) specification examples

--- a/tests/HalfPrecisionFloatTest.php
+++ b/tests/HalfPrecisionFloatTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace CBOR\Test;
 
 use CBOR\OtherObject\HalfPrecisionFloatObject;
-use PHPUnit\Framework\Attributes\Test;
 use const INF;
 use const NAN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal

--- a/tests/SinglePrecisionFloatTest.php
+++ b/tests/SinglePrecisionFloatTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace CBOR\Test;
 
 use CBOR\OtherObject\SinglePrecisionFloatObject;
-use PHPUnit\Framework\Attributes\Test;
 use const INF;
 use const NAN;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal


### PR DESCRIPTION
## Summary
- Fix ECS import ordering (27 errors): `use const`/`use function` must be ordered with class imports
- Add `.agents` to `.gitattributes` export-ignore to fix exported files check

## Test plan
- [ ] ECS check passes
- [ ] Exported files check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)