### PR TITLE
fix(decoder): limit the nesting depth of the decoded data

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -25,6 +25,12 @@ parameters:
 			path: ../src/ByteStringObject.php
 
 		-
+			rawMessage: Constructor in CBOR\Decoder has parameter $maxDepth with default value.
+			identifier: ergebnis.noConstructorParameterWithDefaultValue
+			count: 1
+			path: ../src/Decoder.php
+
+		-
 			rawMessage: Constructor in CBOR\Decoder has parameter $otherTypeManager with default value.
 			identifier: ergebnis.noConstructorParameterWithDefaultValue
 			count: 1

--- a/doc/index.md
+++ b/doc/index.md
@@ -180,6 +180,19 @@ $otherObjectManager = OtherObjectManager::create()
 $decoder = Decoder::create($tagManager, $otherObjectManager);
 ```
 
+#### Limiting the Nesting Depth
+
+Decoding is a recursive operation: a deeply nested data item (e.g. thousands of nested arrays, maps or tags) can
+exhaust the call stack. The decoder therefore rejects data nested deeper than `Decoder::DEFAULT_MAX_DEPTH` (1000
+levels) with an `InvalidArgumentException`.
+
+When the data comes from an untrusted source, a much lower limit is recommended:
+
+```php
+// Accept at most 32 levels of nested arrays, maps and tags
+$decoder = Decoder::create(null, null, 32);
+```
+
 #### Decoding Binary Data
 
 ```php

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -40,32 +40,55 @@ use const STR_PAD_LEFT;
 
 final class Decoder implements DecoderInterface
 {
+    /**
+     * The maximum nesting depth allowed by default. Deeper structures are rejected as the recursive processing of the
+     * data may exhaust the call stack.
+     */
+    public const DEFAULT_MAX_DEPTH = 1000;
+
     private TagManagerInterface $tagObjectManager;
 
     private OtherObjectManagerInterface $otherTypeManager;
 
+    private int $maxDepth;
+
     public function __construct(
         ?TagManagerInterface $tagObjectManager = null,
-        ?OtherObjectManagerInterface $otherTypeManager = null
+        ?OtherObjectManagerInterface $otherTypeManager = null,
+        int $maxDepth = self::DEFAULT_MAX_DEPTH
     ) {
+        if ($maxDepth < 1) {
+            throw new InvalidArgumentException(sprintf(
+                'The maximum nesting depth shall be at least 1. Got %d.',
+                $maxDepth
+            ));
+        }
         $this->tagObjectManager = $tagObjectManager ?? $this->generateTagManager();
         $this->otherTypeManager = $otherTypeManager ?? $this->generateOtherObjectManager();
+        $this->maxDepth = $maxDepth;
     }
 
     public static function create(
         ?TagManagerInterface $tagObjectManager = null,
-        ?OtherObjectManagerInterface $otherTypeManager = null
+        ?OtherObjectManagerInterface $otherTypeManager = null,
+        int $maxDepth = self::DEFAULT_MAX_DEPTH
     ): self {
-        return new self($tagObjectManager, $otherTypeManager);
+        return new self($tagObjectManager, $otherTypeManager, $maxDepth);
     }
 
     public function decode(Stream $stream): CBORObject
     {
-        return $this->process($stream, false);
+        return $this->process($stream, false, 0);
     }
 
-    private function process(Stream $stream, bool $breakable): CBORObject
+    private function process(Stream $stream, bool $breakable, int $depth): CBORObject
     {
+        if ($depth > $this->maxDepth) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot parse the data. Maximum nesting depth of %d exceeded.',
+                $this->maxDepth
+            ));
+        }
         $ib = ord($stream->read(1));
         $mt = $ib >> 5;
         $ai = $ib & 0b00011111;
@@ -86,13 +109,13 @@ final class Decoder implements DecoderInterface
                     $ai
                 ));
             case CBORObject::LENGTH_INDEFINITE: // 31
-                return $this->processInfinite($stream, $mt, $breakable);
+                return $this->processInfinite($stream, $mt, $breakable, $depth);
         }
 
-        return $this->processFinite($stream, $mt, $ai, $val);
+        return $this->processFinite($stream, $mt, $ai, $val, $depth);
     }
 
-    private function processFinite(Stream $stream, int $mt, int $ai, ?string $val): CBORObject
+    private function processFinite(Stream $stream, int $mt, int $ai, ?string $val, int $depth): CBORObject
     {
         switch ($mt) {
             case CBORObject::MAJOR_TYPE_UNSIGNED_INTEGER: // 0
@@ -111,7 +134,7 @@ final class Decoder implements DecoderInterface
                 $object = ListObject::create();
                 $nbItems = $val === null ? $ai : Utils::binToInt($val);
                 for ($i = 0; $i < $nbItems; ++$i) {
-                    $object->add($this->process($stream, false));
+                    $object->add($this->process($stream, false, $depth + 1));
                 }
 
                 return $object;
@@ -119,12 +142,19 @@ final class Decoder implements DecoderInterface
                 $object = MapObject::create();
                 $nbItems = $val === null ? $ai : Utils::binToInt($val);
                 for ($i = 0; $i < $nbItems; ++$i) {
-                    $object->add($this->process($stream, false), $this->process($stream, false));
+                    $object->add(
+                        $this->process($stream, false, $depth + 1),
+                        $this->process($stream, false, $depth + 1)
+                    );
                 }
 
                 return $object;
             case CBORObject::MAJOR_TYPE_TAG: // 6
-                return $this->tagObjectManager->createObjectForValue($ai, $val, $this->process($stream, false));
+                return $this->tagObjectManager->createObjectForValue(
+                    $ai,
+                    $val,
+                    $this->process($stream, false, $depth + 1)
+                );
             case CBORObject::MAJOR_TYPE_OTHER_TYPE: // 7
                 return $this->otherTypeManager->createObjectForValue($ai, $val);
             default:
@@ -136,12 +166,12 @@ final class Decoder implements DecoderInterface
         }
     }
 
-    private function processInfinite(Stream $stream, int $mt, bool $breakable): CBORObject
+    private function processInfinite(Stream $stream, int $mt, bool $breakable, int $depth): CBORObject
     {
         switch ($mt) {
             case CBORObject::MAJOR_TYPE_BYTE_STRING: // 2
                 $object = IndefiniteLengthByteStringObject::create();
-                while (! ($it = $this->process($stream, true)) instanceof BreakObject) {
+                while (! ($it = $this->process($stream, true, $depth + 1)) instanceof BreakObject) {
                     if (! $it instanceof ByteStringObject) {
                         throw new RuntimeException(
                             'Unable to parse the data. Infinite Byte String object can only get Byte String objects.'
@@ -153,7 +183,7 @@ final class Decoder implements DecoderInterface
                 return $object;
             case CBORObject::MAJOR_TYPE_TEXT_STRING: // 3
                 $object = IndefiniteLengthTextStringObject::create();
-                while (! ($it = $this->process($stream, true)) instanceof BreakObject) {
+                while (! ($it = $this->process($stream, true, $depth + 1)) instanceof BreakObject) {
                     if (! $it instanceof TextStringObject) {
                         throw new RuntimeException(
                             'Unable to parse the data. Infinite Text String object can only get Text String objects.'
@@ -165,17 +195,17 @@ final class Decoder implements DecoderInterface
                 return $object;
             case CBORObject::MAJOR_TYPE_LIST: // 4
                 $object = IndefiniteLengthListObject::create();
-                $it = $this->process($stream, true);
+                $it = $this->process($stream, true, $depth + 1);
                 while (! $it instanceof BreakObject) {
                     $object->add($it);
-                    $it = $this->process($stream, true);
+                    $it = $this->process($stream, true, $depth + 1);
                 }
 
                 return $object;
             case CBORObject::MAJOR_TYPE_MAP: // 5
                 $object = IndefiniteLengthMapObject::create();
-                while (! ($it = $this->process($stream, true)) instanceof BreakObject) {
-                    $object->add($it, $this->process($stream, false));
+                while (! ($it = $this->process($stream, true, $depth + 1)) instanceof BreakObject) {
+                    $object->add($it, $this->process($stream, false, $depth + 1));
                 }
 
                 return $object;

--- a/tests/MaxDepthTest.php
+++ b/tests/MaxDepthTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\StringStream;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use function str_repeat;
+
+/**
+ * @internal
+ */
+final class MaxDepthTest extends CBORTestCase
+{
+    #[Test]
+    public function aStructureThatReachesTheMaximumDepthIsDecoded(): void
+    {
+        $data = str_repeat("\x81", Decoder::DEFAULT_MAX_DEPTH) . "\x00";
+
+        $object = $this->getDecoder()
+            ->decode(StringStream::create($data))
+        ;
+
+        static::assertInstanceOf(ListObject::class, $object);
+        static::assertCount(1, $object);
+    }
+
+    #[Test]
+    public function aStructureDeeperThanTheMaximumDepthIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse the data. Maximum nesting depth of 1000 exceeded.');
+
+        $data = str_repeat("\x81", Decoder::DEFAULT_MAX_DEPTH + 1) . "\x00";
+
+        $this->getDecoder()
+            ->decode(StringStream::create($data))
+        ;
+    }
+
+    #[Test]
+    public function theMaximumDepthIsConfigurable(): void
+    {
+        $decoder = Decoder::create(null, null, 2);
+
+        $object = $decoder->decode(StringStream::create("\x81\x81\x00"));
+
+        static::assertInstanceOf(ListObject::class, $object);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse the data. Maximum nesting depth of 2 exceeded.');
+
+        $decoder->decode(StringStream::create("\x81\x81\x81\x00"));
+    }
+
+    #[Test]
+    public function deeplyNestedMapsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse the data. Maximum nesting depth of 2 exceeded.');
+
+        $data = str_repeat("\xa1\x00", 3) . "\x00";
+
+        Decoder::create(null, null, 2)->decode(StringStream::create($data));
+    }
+
+    #[Test]
+    public function deeplyNestedIndefiniteLengthListsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse the data. Maximum nesting depth of 2 exceeded.');
+
+        $data = str_repeat("\x9f", 3) . "\x00" . str_repeat("\xff", 3);
+
+        Decoder::create(null, null, 2)->decode(StringStream::create($data));
+    }
+
+    #[Test]
+    public function deeplyNestedTagsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse the data. Maximum nesting depth of 2 exceeded.');
+
+        $data = str_repeat("\xcb", 3) . "\x00";
+
+        Decoder::create(null, null, 2)->decode(StringStream::create($data));
+    }
+
+    #[Test]
+    public function theMaximumDepthCannotBeLowerThanOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The maximum nesting depth shall be at least 1. Got 0.');
+
+        Decoder::create(null, null, 0);
+    }
+}


### PR DESCRIPTION
## Problem

`CBOR\Decoder` processed nested data items recursively without any bound. A payload made only of nested arrays costs one byte per level (`0x81`), so ~44 KB of input is enough to build an object graph deep enough to crash the process — a segmentation fault, not a catchable error.

The crash does not happen during parsing: `decode()` returns successfully, and the process dies later, when the graph is released, because the destructor chain is recursive on the C stack. The threshold follows the stack size (measured: ~1 600 levels with a 256 KB stack, ~4 000 with 512 KB, ~40 000 with the default 8 MB), so a worker with a reduced stack crashes on a much smaller payload.

Nested arrays are not the only vector: nested maps, tag chains (`0xcb` repeated) and indefinite length containers are all one byte per level too.

## Fix

Nesting depth is now tracked while processing and checked on every nested item — lists, maps, tags and indefinite length containers alike. Data nested deeper than the limit is rejected with an `InvalidArgumentException` instead of building the graph:

```
Cannot parse the data. Maximum nesting depth of 1000 exceeded.
```

The limit defaults to `Decoder::DEFAULT_MAX_DEPTH` (1000 levels) and can be lowered — recommended when the data comes from an untrusted source:

```php
// Accept at most 32 levels of nested arrays, maps and tags
$decoder = Decoder::create(null, null, 32);
```

Backward compatible: the depth is a new optional third argument of `Decoder::__construct()` / `Decoder::create()`, `DecoderInterface` is unchanged, and 1000 levels is far beyond what COSE, CWT or WebAuthn data ever reaches.

## Tests

`tests/MaxDepthTest.php` covers the limit being reached, exceeded, and configured, each of the four nesting vectors, and the rejection of a limit lower than 1.

Full suite: 497 tests, 1103 assertions, ECS and parallel-lint clean. PHPStan reports 4 errors on `NegativeIntegerObject` / `UnsignedIntegerObject`, all pre-existing on `3.3.x` and unrelated to this change; `Decoder.php` is clean.

Reported by [Ivan Tse](https://github.com/ivantsepp).