### PR TITLE
fix(map): key the map entries by their key, not by their position

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -257,6 +257,13 @@ $map->add(
     TextStringObject::create('Alice')
 );
 
+// A map may also be built from MapItem objects. Duplicate keys are rejected,
+// as are two keys of different major types that resolve to the same offset.
+$map = MapObject::create([
+    MapItem::create(TextStringObject::create('name'), TextStringObject::create('Alice')),
+    MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2)),
+]);
+
 // Access values
 $name = $map->get('name');
 
@@ -350,8 +357,16 @@ $list = IndefiniteLengthListObject::create()
 
 // Indefinite-length map
 $map = IndefiniteLengthMapObject::create()
-    ->append(TextStringObject::create('key1'), UnsignedIntegerObject::create(1))
-    ->append(TextStringObject::create('key2'), UnsignedIntegerObject::create(2));
+    ->add(TextStringObject::create('key1'), UnsignedIntegerObject::create(1))
+    ->add(TextStringObject::create('key2'), UnsignedIntegerObject::create(2));
+```
+
+Indefinite-length lists and maps are `Countable`, just like their definite-length counterparts, so `count()`
+works whichever encoding a document uses:
+
+```php
+$decoded = $decoder->decode(StringStream::create($data));
+$count = count($decoded);
 ```
 
 ### Custom Streams

--- a/src/IndefiniteLengthListObject.php
+++ b/src/IndefiniteLengthListObject.php
@@ -7,6 +7,8 @@ namespace CBOR;
 use function array_key_exists;
 use ArrayAccess;
 use ArrayIterator;
+use function count;
+use Countable;
 use InvalidArgumentException;
 use Iterator;
 use IteratorAggregate;
@@ -16,7 +18,7 @@ use IteratorAggregate;
  * @phpstan-implements IteratorAggregate<int, CBORObject>
  * @final
  */
-class IndefiniteLengthListObject extends AbstractCBORObject implements IteratorAggregate, Normalizable, ArrayAccess
+class IndefiniteLengthListObject extends AbstractCBORObject implements Countable, IteratorAggregate, Normalizable, ArrayAccess
 {
     private const MAJOR_TYPE = self::MAJOR_TYPE_LIST;
 
@@ -104,6 +106,11 @@ class IndefiniteLengthListObject extends AbstractCBORObject implements IteratorA
         $this->data[$index] = $object;
 
         return $this;
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
     }
 
     /**

--- a/src/IndefiniteLengthMapObject.php
+++ b/src/IndefiniteLengthMapObject.php
@@ -7,6 +7,8 @@ namespace CBOR;
 use function array_key_exists;
 use ArrayAccess;
 use ArrayIterator;
+use function count;
+use Countable;
 use InvalidArgumentException;
 use Iterator;
 use IteratorAggregate;
@@ -16,7 +18,7 @@ use IteratorAggregate;
  * @phpstan-implements IteratorAggregate<int, MapItem>
  * @final
  */
-class IndefiniteLengthMapObject extends AbstractCBORObject implements IteratorAggregate, Normalizable, ArrayAccess
+class IndefiniteLengthMapObject extends AbstractCBORObject implements Countable, IteratorAggregate, Normalizable, ArrayAccess
 {
     use MapKeyRegistryTrait;
 
@@ -71,8 +73,7 @@ class IndefiniteLengthMapObject extends AbstractCBORObject implements IteratorAg
             return $this;
         }
         unset($this->data[$index]);
-        $this->data = array_values($this->data);
-        $this->rebuildKeyIdentities($this->data);
+        $this->unregisterKey($index);
 
         return $this;
     }
@@ -91,6 +92,11 @@ class IndefiniteLengthMapObject extends AbstractCBORObject implements IteratorAg
         $this->data[$this->registerKey($object->getKey(), true)] = $object;
 
         return $this;
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
     }
 
     /**

--- a/src/MapKeyRegistryTrait.php
+++ b/src/MapKeyRegistryTrait.php
@@ -63,16 +63,31 @@ trait MapKeyRegistryTrait
         return $offset;
     }
 
+    private function unregisterKey(int|string $offset): void
+    {
+        unset($this->keyIdentities[$offset]);
+    }
+
     /**
      * @param MapItem[] $data
+     *
+     * @return MapItem[] the entries, re-keyed by their normalized key
      */
-    private function rebuildKeyIdentities(array $data): void
+    private function registerKeys(array $data): array
     {
-        $this->keyIdentities = [];
-        foreach ($data as $offset => $item) {
-            $key = $item->getKey();
-            $this->keyIdentities[$offset] = $key->getMajorType() . ':' . self::assertNormalizableToScalar($key);
+        $entries = [];
+        foreach ($data as $item) {
+            if (! $item instanceof MapItem) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid item. A map shall only contain "%s" objects, got "%s".',
+                    MapItem::class,
+                    get_debug_type($item)
+                ));
+            }
+            $entries[$this->registerKey($item->getKey(), false)] = $item;
         }
+
+        return $entries;
     }
 
     /**

--- a/src/MapObject.php
+++ b/src/MapObject.php
@@ -35,11 +35,11 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
      */
     public function __construct(array $data = [])
     {
-        [$additionalInformation, $length] = LengthCalculator::getLengthOfArray($data);
+        $entries = $this->registerKeys($data);
+        [$additionalInformation, $length] = LengthCalculator::getLengthOfArray($entries);
         parent::__construct(self::MAJOR_TYPE, $additionalInformation);
-        $this->data = $data;
+        $this->data = $entries;
         $this->length = $length;
-        $this->rebuildKeyIdentities($data);
     }
 
     public function __toString(): string
@@ -84,8 +84,7 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
             return $this;
         }
         unset($this->data[$index]);
-        $this->data = array_values($this->data);
-        $this->rebuildKeyIdentities($this->data);
+        $this->unregisterKey($index);
         [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
 
         return $this;

--- a/tests/MapKeyRegistryTest.php
+++ b/tests/MapKeyRegistryTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\ByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\StringStream;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Countable;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for https://github.com/Spomky-Labs/cbor-php/issues/152.
+ *
+ * `MapObject::__construct()` stored the caller's entries as they came, and both `remove()` implementations reindexed
+ * the remaining entries with `array_values()`. In both cases the map ended up keyed by list offsets instead of by
+ * normalized keys, which defeats the key registry: duplicates went undetected, `has()`/`get()` by key failed, and
+ * `add()` reported collisions between keys that were not in the map at all.
+ *
+ * @internal
+ */
+final class MapKeyRegistryTest extends CBORTestCase
+{
+    #[Test]
+    public function theConstructorRejectsDuplicateKeys(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid key. The key "a" is defined more than once in the map.');
+
+        MapObject::create([
+            MapItem::create(TextStringObject::create('a'), UnsignedIntegerObject::create(1)),
+            MapItem::create(TextStringObject::create('a'), UnsignedIntegerObject::create(2)),
+        ]);
+    }
+
+    #[Test]
+    public function theConstructorRejectsKeysThatCollideOnTheSameOffset(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('both resolve to the offset "1"');
+
+        MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(1)),
+            MapItem::create(TextStringObject::create('1'), UnsignedIntegerObject::create(2)),
+        ]);
+    }
+
+    #[Test]
+    public function theConstructorRejectsEntriesThatAreNotMapItems(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A map shall only contain "CBOR\MapItem" objects, got "CBOR\TextStringObject".');
+
+        /** @phpstan-ignore-next-line */
+        MapObject::create([TextStringObject::create('a')]);
+    }
+
+    #[Test]
+    public function theConstructorRegistersTheEntriesUnderTheirKey(): void
+    {
+        $object = MapObject::create([
+            MapItem::create(TextStringObject::create('a'), UnsignedIntegerObject::create(1)),
+            MapItem::create(UnsignedIntegerObject::create(10), TextStringObject::create('Hello')),
+            MapItem::create(ByteStringObject::create('AZERTY'), UnsignedIntegerObject::create(2)),
+        ]);
+
+        static::assertCount(3, $object);
+        static::assertTrue($object->has('a'));
+        static::assertTrue($object->has(10));
+        static::assertTrue($object->has('AZERTY'));
+        static::assertSame('1', $object->get('a')->normalize());
+        static::assertSame('Hello', $object->get(10)->normalize());
+        static::assertSame([
+            'a' => '1',
+            10 => 'Hello',
+            'AZERTY' => '2',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function aMapBuiltFromItemsIsDecodedBackToItself(): void
+    {
+        $object = MapObject::create([
+            MapItem::create(TextStringObject::create('a'), UnsignedIntegerObject::create(1)),
+            MapItem::create(TextStringObject::create('b'), UnsignedIntegerObject::create(2)),
+        ]);
+
+        $decoded = $this->getDecoder()
+            ->decode(StringStream::create((string) $object));
+
+        static::assertSame($object->normalize(), $decoded->normalize());
+    }
+
+    #[Test]
+    public function removingAnEntryKeepsTheOtherEntriesAddressableByKey(): void
+    {
+        $object = MapObject::create()
+            ->add(TextStringObject::create('a'), UnsignedIntegerObject::create(1))
+            ->add(TextStringObject::create('b'), UnsignedIntegerObject::create(2))
+            ->add(TextStringObject::create('c'), UnsignedIntegerObject::create(3))
+            ->remove('a')
+        ;
+
+        static::assertCount(2, $object);
+        static::assertFalse($object->has('a'));
+        static::assertTrue($object->has('b'));
+        static::assertSame('2', $object->get('b')->normalize());
+        static::assertSame([
+            'b' => '2',
+            'c' => '3',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function removingAnEntryDoesNotFreeTheOffsetsOfTheRemainingKeys(): void
+    {
+        $object = MapObject::create()
+            ->add(TextStringObject::create('a'), UnsignedIntegerObject::create(1))
+            ->add(TextStringObject::create('b'), UnsignedIntegerObject::create(2))
+            ->remove('a')
+        ;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid key. The key "b" is defined more than once in the map.');
+
+        $object->add(TextStringObject::create('b'), UnsignedIntegerObject::create(9));
+    }
+
+    #[Test]
+    public function removingAnEntryFreesItsOwnOffsetForAnotherMajorType(): void
+    {
+        $object = MapObject::create()
+            ->add(TextStringObject::create('0'), UnsignedIntegerObject::create(1))
+            ->add(TextStringObject::create('b'), UnsignedIntegerObject::create(2))
+            ->remove('0')
+            ->add(UnsignedIntegerObject::create(0), UnsignedIntegerObject::create(9))
+        ;
+
+        static::assertCount(2, $object);
+        static::assertSame([
+            'b' => '2',
+            0 => '9',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function aMapIsStillEncodedWithTheRightLengthAfterARemoval(): void
+    {
+        $object = MapObject::create()
+            ->add(TextStringObject::create('a'), UnsignedIntegerObject::create(1))
+            ->add(TextStringObject::create('b'), UnsignedIntegerObject::create(2))
+            ->add(TextStringObject::create('c'), UnsignedIntegerObject::create(3))
+            ->remove('b')
+        ;
+
+        static::assertSame(hex2bin('a2616101616303'), (string) $object);
+
+        $decoded = $this->getDecoder()
+            ->decode(StringStream::create((string) $object));
+
+        static::assertSame([
+            'a' => '1',
+            'c' => '3',
+        ], $decoded->normalize());
+    }
+
+    #[Test]
+    public function removingAnEntryOfAnIndefiniteLengthMapKeepsTheOtherEntriesAddressableByKey(): void
+    {
+        $object = IndefiniteLengthMapObject::create()
+            ->add(TextStringObject::create('a'), UnsignedIntegerObject::create(1))
+            ->add(TextStringObject::create('b'), UnsignedIntegerObject::create(2))
+            ->add(TextStringObject::create('c'), UnsignedIntegerObject::create(3))
+            ->remove('a')
+        ;
+
+        static::assertCount(2, $object);
+        static::assertFalse($object->has('a'));
+        static::assertTrue($object->has('b'));
+        static::assertSame('2', $object->get('b')->normalize());
+        static::assertSame(hex2bin('bf616202616303ff'), (string) $object);
+    }
+
+    #[Test]
+    public function anIndefiniteLengthMapIsCountable(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('bf616101616202ff')));
+
+        static::assertInstanceOf(IndefiniteLengthMapObject::class, $object);
+        static::assertInstanceOf(Countable::class, $object);
+        static::assertSame(2, $object->count());
+    }
+
+    #[Test]
+    public function anIndefiniteLengthListIsCountable(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('9f010203ff')));
+
+        static::assertInstanceOf(IndefiniteLengthListObject::class, $object);
+        static::assertInstanceOf(Countable::class, $object);
+        static::assertSame(3, $object->count());
+
+        static::assertCount(2, IndefiniteLengthListObject::create(
+            UnsignedIntegerObject::create(1),
+            UnsignedIntegerObject::create(2),
+        ));
+    }
+}


### PR DESCRIPTION
Closes #152.

## Problem

`MapObject` and `IndefiniteLengthMapObject` store entries in a native PHP array whose offset is the *normalized key*, and `MapKeyRegistryTrait` tracks the major type behind each occupied offset. Two code paths broke that invariant by storing entries under **list offsets** instead:

* `MapObject::__construct()` kept the caller's array as-is and only recorded identities under `0..n-1`.
* Both `remove()` implementations called `array_values()`, turning every remaining offset back into a position.

Consequences:

* duplicate keys passed to the constructor went undetected and were emitted on the wire — where the library's own decoder then rejected the result with *"The key 'a' is defined more than once in the map."*;
* after a `remove()`, `has('b')` returned `false`, `get('b')` threw *Index not found.*, `add('b', …)` was accepted (duplicate on the wire) and `add(uint 0, …)` was rejected as a collision with a key that no longer existed;
* the constructor accepted non-`MapItem` values and later died with `Error: Call to undefined method …::getKey()`.

Separately, `IndefiniteLengthListObject` / `IndefiniteLengthMapObject` were not `Countable`, so `count($decoded)` threw a `TypeError` for indefinite-length containers while working for definite-length ones.

## Fix

* `MapObject::__construct()` runs every entry through the registry (`registerKeys()`), so duplicates and cross-major-type offset collisions are rejected up front and entries land under their normalized key. Non-`MapItem` values now raise an `InvalidArgumentException` instead of a fatal `Error`.
* `remove()` drops the entry and its registry slot (`unregisterKey()`) and leaves the other offsets alone; the encoded length is recomputed from the remaining entries.
* `IndefiniteLengthListObject` and `IndefiniteLengthMapObject` implement `Countable`.
* `doc/index.md`: document building a map from `MapItem` objects and `count()` on indefinite-length containers; fix a snippet that called a non-existent `IndefiniteLengthMapObject::append()`.

`rebuildKeyIdentities()` had no remaining caller and was replaced by `registerKeys()` / `unregisterKey()`. `ListObject::remove()` keeps `array_values()` — a list's indices *are* positions.

## Tests

New `tests/MapKeyRegistryTest.php` (12 cases). 10 of them fail on `3.3.x` before the change:

```
Tests: 12, Assertions: 17, Errors: 3, Failures: 7.
```

and all pass after. Full local CI is green: `castor lint`, `castor ecs`, `castor rector`, `castor phpstan`, `castor deptrac`, `castor phpunit` (619 tests, 1369 assertions).
