### PR TITLE
fix: shortest-form tag numbers and bignum mantissas

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CBOR;
 
 use CBOR\Tag\TagInterface;
+use function chr;
 use InvalidArgumentException;
 
 abstract class Tag extends AbstractCBORObject implements TagInterface
@@ -40,35 +41,25 @@ abstract class Tag extends AbstractCBORObject implements TagInterface
     }
 
     /**
+     * A tag number is the argument of a major type 6 head, so RFC 8949 section 3 gives it the same five encodings as
+     * any other argument and section 4.2 requires the shortest one that holds it. The bounds are therefore inclusive
+     * and each payload is packed to the exact width its additional information announces: 255 is the largest
+     * one-byte tag number, not the first two-byte one, and tag 256 is "d9 0100", never a single byte.
+     *
      * @return array{int, null|string}
      */
     protected static function determineComponents(int $tag): array
     {
-        switch (true) {
-            case $tag < 0:
-                throw new InvalidArgumentException('The value must be a positive integer.');
-            case $tag < 24:
-                return [$tag, null];
-            case $tag < 0xFF:
-                return [24, self::hex2bin(dechex($tag))];
-            case $tag < 0xFFFF:
-                return [25, self::hex2bin(dechex($tag))];
-            case $tag < 0xFFFFFFFF:
-                return [26, self::hex2bin(dechex($tag))];
-            default:
-                throw new InvalidArgumentException(
-                    'Out of range. Please use PositiveBigIntegerTag tag with ByteStringObject object instead.'
-                );
-        }
-    }
-
-    private static function hex2bin(string $data): string
-    {
-        $result = hex2bin($data);
-        if ($result === false) {
-            throw new InvalidArgumentException('Unable to convert the data');
+        if ($tag < 0) {
+            throw new InvalidArgumentException('The value must be a positive integer.');
         }
 
-        return $result;
+        return match (true) {
+            $tag <= 23 => [$tag, null],
+            $tag <= 0xFF => [self::LENGTH_1_BYTE, chr($tag)],
+            $tag <= 0xFFFF => [self::LENGTH_2_BYTES, pack('n', $tag)],
+            $tag <= 0xFFFFFFFF => [self::LENGTH_4_BYTES, pack('N', $tag)],
+            default => [self::LENGTH_8_BYTES, pack('J', $tag)],
+        };
     }
 }

--- a/src/Tag/DecimalFractionTag.php
+++ b/src/Tag/DecimalFractionTag.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CBOR\Tag;
 
 use Brick\Math\BigInteger;
+use CBOR\ByteStringObject;
 use CBOR\CBORObject;
 use CBOR\ListObject;
 use CBOR\NegativeIntegerObject;
@@ -16,6 +17,7 @@ use function extension_loaded;
 use InvalidArgumentException;
 use RuntimeException;
 use function sprintf;
+use function str_starts_with;
 use function strlen;
 
 final class DecimalFractionTag extends Tag implements Normalizable
@@ -157,15 +159,56 @@ final class DecimalFractionTag extends Tag implements Normalizable
             $exponentObj = NegativeIntegerObject::create($exponent);
         }
 
-        // Create mantissa object
-        $mantissaInt = (int) $mantissa;
-        if ($mantissaInt >= 0) {
-            $mantissaObj = UnsignedIntegerObject::createFromString($mantissa);
-        } else {
-            $mantissaObj = NegativeIntegerObject::createFromString($mantissa);
+        return self::createFromExponentAndMantissa($exponentObj, self::mantissaObject($mantissa));
+    }
+
+    /**
+     * The mantissa of a decimal fraction is only bounded by the requested precision, so it routinely outgrows the
+     * 8-byte argument an integer head can carry. RFC 8949 section 3.4.3 answers that with the bignum tags the
+     * constructor already accepts, and this picks whichever of the four representations fits.
+     *
+     * The sign is read off the string rather than from a PHP integer cast, which saturates at PHP_INT_MIN or
+     * PHP_INT_MAX and would report the wrong sign for exactly the long mantissas this has to handle.
+     */
+    private static function mantissaObject(string $mantissa): CBORObject
+    {
+        $value = BigInteger::of($mantissa);
+        if (str_starts_with($mantissa, '-')) {
+            $argument = BigInteger::of(-1)->minus($value);
+
+            return $argument->isLessThanOrEqualTo(self::maximumHeadArgument())
+                ? NegativeIntegerObject::createFromString($mantissa)
+                : NegativeBigIntegerTag::create(ByteStringObject::create(self::toBigEndianBytes($argument)));
         }
 
-        return self::createFromExponentAndMantissa($exponentObj, $mantissaObj);
+        return $value->isLessThanOrEqualTo(self::maximumHeadArgument())
+            ? UnsignedIntegerObject::createFromString($mantissa)
+            : UnsignedBigIntegerTag::create(ByteStringObject::create(self::toBigEndianBytes($value)));
+    }
+
+    /**
+     * Largest argument an integer head can carry, 2^64 - 1. Beyond it a bignum tag is the only representation.
+     */
+    private static function maximumHeadArgument(): BigInteger
+    {
+        return BigInteger::fromBase('FFFFFFFFFFFFFFFF', 16);
+    }
+
+    /**
+     * The network byte order, unsigned, no leading zero byte representation a bignum tag wraps.
+     */
+    private static function toBigEndianBytes(BigInteger $value): string
+    {
+        $hex = $value->toBase(16);
+        if (strlen($hex) % 2 === 1) {
+            $hex = '0' . $hex;
+        }
+        $bytes = hex2bin($hex);
+        if ($bytes === false) {
+            throw new InvalidArgumentException('Unable to convert the data');
+        }
+
+        return $bytes;
     }
 
     public function normalize()

--- a/src/UnsignedIntegerObject.php
+++ b/src/UnsignedIntegerObject.php
@@ -97,7 +97,7 @@ final class UnsignedIntegerObject extends AbstractCBORObject implements Normaliz
         }
         if ($integer->isGreaterThan(self::maximumArgument())) {
             throw new InvalidArgumentException(
-                'Out of range. Please use PositiveBigIntegerTag tag with ByteStringObject object instead.'
+                'Out of range. Please use UnsignedBigIntegerTag tag with ByteStringObject object instead.'
             );
         }
 

--- a/tests/DecimalFractionTagTest.php
+++ b/tests/DecimalFractionTagTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace CBOR\Test;
 
+use CBOR\ListObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
 use CBOR\Tag\DecimalFractionTag;
+use CBOR\Tag\NegativeBigIntegerTag;
+use CBOR\Tag\UnsignedBigIntegerTag;
+use CBOR\UnsignedIntegerObject;
 use function extension_loaded;
 use const INF;
 use InvalidArgumentException;
@@ -280,5 +286,76 @@ final class DecimalFractionTagTest extends CBORTestCase
         $normalized = (float) $obj->normalize();
 
         static::assertEqualsWithDelta($value, $normalized, 0.00001);
+    }
+
+    /**
+     * A precision beyond ~19 digits pushes the mantissa past the 8-byte argument an integer head can carry, where
+     * RFC 8949 section 3.4.3 asks for a bignum instead.
+     */
+    #[Test]
+    public function aMantissaLargerThanEightBytesIsWrappedInAnUnsignedBignum(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $obj = DecimalFractionTag::createFromFloat(0.1, 40);
+
+        /** @var ListObject $list */
+        $list = $obj->getValue();
+        static::assertInstanceOf(UnsignedBigIntegerTag::class, $list->get(1));
+        static::assertSame('0.1000000000000000055511151231257827021182', $obj->normalize());
+    }
+
+    #[Test]
+    public function aNegativeMantissaLargerThanEightBytesIsWrappedInANegativeBignum(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $obj = DecimalFractionTag::createFromFloat(-0.1, 40);
+
+        /** @var ListObject $list */
+        $list = $obj->getValue();
+        static::assertInstanceOf(NegativeBigIntegerTag::class, $list->get(1));
+        static::assertSame('-0.1000000000000000055511151231257827021182', $obj->normalize());
+    }
+
+    #[Test]
+    public function aBignumMantissaSurvivesADecodingRoundTrip(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $obj = DecimalFractionTag::createFromFloat(-0.1, 40);
+        $data = (string) $obj;
+
+        $decoded = $this->getDecoder()
+            ->decode(StringStream::create($data))
+        ;
+        static::assertInstanceOf(DecimalFractionTag::class, $decoded);
+        static::assertSame($obj->normalize(), $decoded->normalize());
+    }
+
+    /**
+     * A mantissa that still fits an integer head shall keep using one: the bignum tag is the fallback, not the
+     * default.
+     */
+    #[Test]
+    public function aMantissaThatFitsAHeadIsNotWrappedInABignum(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        /** @var ListObject $positive */
+        $positive = DecimalFractionTag::createFromFloat(3.14159)->getValue();
+        static::assertInstanceOf(UnsignedIntegerObject::class, $positive->get(1));
+
+        /** @var ListObject $negative */
+        $negative = DecimalFractionTag::createFromFloat(-3.14159)->getValue();
+        static::assertInstanceOf(NegativeIntegerObject::class, $negative->get(1));
     }
 }

--- a/tests/Tag/ArbitraryNumberTag.php
+++ b/tests/Tag/ArbitraryNumberTag.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Tag;
+
+/**
+ * Every shipped tag hard-codes its own number, so the head computation can only be exercised through a tag that
+ * takes the number as an argument -- the very thing doc/custom-tags.md tells implementors to write.
+ *
+ * @internal
+ */
+final class ArbitraryNumberTag extends Tag
+{
+    public static function getTagId(): int
+    {
+        return -1;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function createWithTagNumber(int $tag, CBORObject $object): self
+    {
+        [$additionalInformation, $data] = self::determineComponents($tag);
+
+        return new self($additionalInformation, $data, $object);
+    }
+}

--- a/tests/Tag/TagNumberEncodingTest.php
+++ b/tests/Tag/TagNumberEncodingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\StringStream;
+use CBOR\Tag;
+use CBOR\Test\CBORTestCase;
+use InvalidArgumentException;
+use Iterator;
+use const PHP_INT_MAX;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A tag number is the argument of a major type 6 head: RFC 8949 section 4.2 asks for the shortest of the five heads
+ * that holds it, and the payload has to fill the width that head announces so the decoder reads it back.
+ *
+ * @internal
+ */
+final class TagNumberEncodingTest extends CBORTestCase
+{
+    #[DataProvider('getTagNumber')]
+    #[Test]
+    public function aTagNumberIsEncodedInItsShortestFormAndDecodedBack(int $tag, string $expectedEncodedData): void
+    {
+        $data = (string) ArbitraryNumberTag::createWithTagNumber($tag, ByteStringObject::create('x'));
+        static::assertSame($expectedEncodedData, bin2hex($data));
+
+        $decoded = $this->getDecoder()
+            ->decode(StringStream::create($data))
+        ;
+        static::assertInstanceOf(Tag::class, $decoded);
+        static::assertSame(CBORObject::MAJOR_TYPE_TAG, $decoded->getMajorType());
+        static::assertSame($data, (string) $decoded);
+    }
+
+    public static function getTagNumber(): Iterator
+    {
+        yield [6, 'c64178'];
+        yield [23, 'd74178'];
+        yield [24, 'd8184178'];
+        yield [255, 'd8ff4178'];
+        yield [256, 'd901004178'];
+        yield [4095, 'd90fff4178'];
+        yield [65_535, 'd9ffff4178'];
+        yield [65_536, 'da000100004178'];
+        yield [1_048_575, 'da000fffff4178'];
+        yield [4_294_967_295, 'daffffffff4178'];
+        yield [4_294_967_296, 'db00000001000000004178'];
+        yield [PHP_INT_MAX, 'db7fffffffffffffff4178'];
+    }
+
+    #[Test]
+    public function aNegativeTagNumberIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value must be a positive integer.');
+
+        ArbitraryNumberTag::createWithTagNumber(-1, ByteStringObject::create('x'));
+    }
+}

--- a/tests/UnsignedIntegerTest.php
+++ b/tests/UnsignedIntegerTest.php
@@ -104,7 +104,7 @@ final class UnsignedIntegerTest extends CBORTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Out of range. Please use PositiveBigIntegerTag tag with ByteStringObject object instead.'
+            'Out of range. Please use UnsignedBigIntegerTag tag with ByteStringObject object instead.'
         );
         UnsignedIntegerObject::createFromString('18446744073709551616');
     }


### PR DESCRIPTION
Closes #150.

Part (a) of the issue — the integer heads — landed in #155. This finishes the other two.

## (b) Tag numbers

`Tag::determineComponents()` compared with a strict `<` and built the payload with `hex2bin(dechex($tag))`, without left-padding. A tag number is the argument of a major type 6 head, so RFC 8949 §3 gives it the same five encodings as any other argument and §4.2 asks for the shortest one that holds it.

| tag | before | after |
| --- | --- | --- |
| 255 | `d9 ff` — an `ai=25` head with a single data byte, unreadable | `d8 ff` |
| 256 | `hex2bin(): odd length` warning, then `Unable to convert the data` | `d9 0100` |
| 4095 | same failure | `d9 0fff` |
| 65535 | `da ffff` — an `ai=26` head with two data bytes | `d9 ffff` |
| 65536 | same failure | `da 00010000` |
| 4294967295 | `Out of range. Please use PositiveBigIntegerTag …` | `da ffffffff` |
| 4294967296 | same | `db 0000000100000000` |

The bounds are now inclusive and each payload is packed to the exact width its additional information announces, with the `ai=27` form covering the rest of the range a PHP integer can express. The `doc/custom-tags.md` examples (tags 260 and 1000) work as written.

## (c) `DecimalFractionTag::createFromFloat()`

The mantissa is built from a decimal string whose length only depends on the requested precision, then handed to `UnsignedIntegerObject::createFromString()`, which stops at the largest argument an integer head can carry — so `createFromFloat(0.1, 40)` threw `Out of range`. It now falls back to the `UnsignedBigIntegerTag` / `NegativeBigIntegerTag` representation the constructor already accepts, and keeps the integer head whenever the mantissa still fits one.

The sign is read off the string as well: the previous `(int) $mantissa` test saturates at `PHP_INT_MIN`/`PHP_INT_MAX` for exactly the long mantissas this has to handle.

`BigFloatTag::createFromFloat()` needed nothing further — its mantissa is at most 53 bits, which #155 already made encodable.

Also corrects the out-of-range message of `UnsignedIntegerObject`, which named a `PositiveBigIntegerTag` class that does not exist.

## Tests

- `tests/Tag/TagNumberEncodingTest.php` — every boundary from 0 to `PHP_INT_MAX`, asserting the exact bytes and a decode round-trip.
- Four cases in `tests/DecimalFractionTagTest.php` — positive and negative bignum mantissas, a decode round-trip, and a guard that a mantissa fitting a head is not needlessly wrapped.

`castor ecs`, `rector`, `phpstan`, `deptrac`, `lint` and `phpunit` (624 tests) all pass.
