### PR TITLE
Déprécier SelfDescribeCBORTag au profit de CBORTag

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -399,12 +399,12 @@ $decoded = $decoder->decode(StringStream::create($tag->getValue()->getValue()));
 
 A "magic number" that marks the beginning of a CBOR data stream. This helps decoders quickly identify CBOR-encoded data.
 
-**Class:** `CBOR\Tag\SelfDescribeCBORTag`
+**Class:** `CBOR\Tag\CBORTag`
 **Spec:** [RFC 8949 § 3.4.6](https://datatracker.ietf.org/doc/html/rfc8949#section-3.4.6)
 **Tag Number:** `55799` (0xd9d9f7 in hex)
 
 ```php
-use CBOR\Tag\SelfDescribeCBORTag;
+use CBOR\Tag\CBORTag;
 use CBOR\MapObject;
 use CBOR\TextStringObject;
 
@@ -412,17 +412,26 @@ use CBOR\TextStringObject;
 $data = MapObject::create()
     ->add(TextStringObject::create('key'), TextStringObject::create('value'));
 
-$selfDescribed = SelfDescribeCBORTag::create($data);
+$selfDescribed = CBORTag::create($data);
 
 // When encoded, this will start with the bytes: d9 d9 f7
 $encoded = (string) $selfDescribed;
 
 // Retrieve the wrapped object
-$innerObject = $selfDescribed->getCBORObject();
+$innerObject = $selfDescribed->getValue();
+
+// Or normalize straight through to the wrapped value
+$value = $selfDescribed->normalize();
 ```
 
 **Accepts:** Any `CBORObject`
 **Purpose:** Allows decoders to rapidly identify CBOR data without parsing
+
+> **Deprecated:** `CBOR\Tag\SelfDescribeCBORTag` also declares tag 55799 and was documented here until
+> 3.3.5. A tag manager registers one class per tag number, and `CBORTag` is the one the default decoder
+> uses, so decoding a self-described document always yields a `CBORTag`. Use `CBORTag`;
+> `SelfDescribeCBORTag` will be removed in 4.0.0. Its `getCBORObject()` is a duplicate of the inherited
+> `getValue()`.
 
 ---
 
@@ -505,7 +514,7 @@ The CBOR Tags registry is maintained by IANA. This library implements the most c
 | 33 | Base64url | `Base64UrlTag` | RFC 8949 § 3.4.5.2 |
 | 34 | Base64 | `Base64Tag` | RFC 8949 § 3.4.5.2 |
 | 36 | MIME Message | `MimeTag` | RFC 8949 § 3.4.5.3 |
-| 55799 | Self-Describe CBOR | `SelfDescribeCBORTag` | RFC 8949 § 3.4.6 |
+| 55799 | Self-Describe CBOR | `CBORTag` | RFC 8949 § 3.4.6 |
 
 ### Unsupported Tags
 

--- a/src/Tag/CBORTag.php
+++ b/src/Tag/CBORTag.php
@@ -8,6 +8,15 @@ use CBOR\CBORObject;
 use CBOR\Normalizable;
 use CBOR\Tag;
 
+/**
+ * Tag 55799: Self-Described CBOR
+ *
+ * This tag is used to mark CBOR data to enable a decoder to rapidly identify
+ * that the data item is in CBOR encoding. This tag is intentionally placed at
+ * a high tag number to minimize collision with other applications.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8949#section-3.4.6
+ */
 final class CBORTag extends Tag implements Normalizable
 {
     public static function getTagId(): int

--- a/src/Tag/SelfDescribeCBORTag.php
+++ b/src/Tag/SelfDescribeCBORTag.php
@@ -15,6 +15,13 @@ use CBOR\Tag;
  * a high tag number to minimize collision with other applications.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc8949#section-3.4.6
+ *
+ * @deprecated since 3.3.5, use {@see CBORTag} instead. Will be removed in 4.0.0.
+ *
+ * Both classes declare tag 55799, but a tag manager can only register one class per tag number.
+ * `CBORTag` is the one registered by the default decoder, so a decoded self-described document is
+ * always a `CBORTag`, never a `SelfDescribeCBORTag`. `CBORTag` also implements `Normalizable`.
+ * `getCBORObject()` has no equivalent on `CBORTag`; use the inherited `getValue()`, which it duplicates.
  */
 final class SelfDescribeCBORTag extends Tag
 {

--- a/tests/SelfDescribeCBORTagTest.php
+++ b/tests/SelfDescribeCBORTagTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CBOR\Test;
 
+use CBOR\StringStream;
+use CBOR\Tag\CBORTag;
 use CBOR\Tag\SelfDescribeCBORTag;
 use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
@@ -78,5 +80,32 @@ final class SelfDescribeCBORTagTest extends CBORTestCase
 
         $retrieved = $tag->getCBORObject();
         static::assertSame($originalValue, $retrieved->normalize());
+    }
+
+    /**
+     * SelfDescribeCBORTag is deprecated in favour of CBORTag, which is the class the default decoder
+     * registers for tag 55799. The two must stay byte-for-byte interchangeable so that migrating is safe.
+     */
+    #[Test]
+    public function selfDescribeCBORTagEncodesExactlyLikeTheCBORTagItIsDeprecatedInFavourOf(): void
+    {
+        $innerObject = TextStringObject::create('CBOR');
+
+        static::assertSame(
+            (string) CBORTag::create($innerObject),
+            (string) SelfDescribeCBORTag::create($innerObject)
+        );
+    }
+
+    #[Test]
+    public function aSelfDescribeCBORTagIsDecodedBackAsACBORTag(): void
+    {
+        $tag = SelfDescribeCBORTag::create(TextStringObject::create('CBOR'));
+
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) $tag));
+
+        static::assertInstanceOf(CBORTag::class, $object);
+        static::assertSame('CBOR', $object->normalize());
     }
 }


### PR DESCRIPTION
Suite de #156 / #149, comme convenu dans une PR distincte.

## Contexte

`CBORTag` et `SelfDescribeCBORTag` déclarent toutes deux le tag 55799 (`self::TAG_CBOR`). Un gestionnaire de tags indexant par `getTagId()`, elles sont mutuellement exclusives : une seule peut occuper la case 55799, la dernière `add()` écrasant la précédente.

Avant #156, l'indexation se faisait par position et la case 55799 n'était occupée par personne — le doublon était donc invisible. Maintenant que la résolution est correcte, il faut trancher.

## Arbitrage : garder `CBORTag`

| | `CBORTag` | `SelfDescribeCBORTag` |
|---|---|---|
| Introduite | 2021 (9e7ed64) | 2025-11 (44c06e4, livrée en 3.3.0) |
| Dans la liste par défaut du `Decoder` | oui | non |
| `Normalizable` | oui | non |
| Apport propre | — | `getCBORObject()`, doublon de `Tag::getValue()` |

Le rayon d'impact de la dépréciation est faible : aucun décodage n'a jamais produit une `SelfDescribeCBORTag`, donc personne ne peut dépendre d'un `instanceof` sur un résultat de décodage. Seuls les appels directs à `SelfDescribeCBORTag::create()` sont concernés, et ils se remplacent ligne pour ligne par `CBORTag::create()`.

À l'inverse, faire de `SelfDescribeCBORTag` la classe canonique casserait le chemin principal et, faute de `Normalizable`, recréerait le symptôme de #149.

Le seul argument en sa faveur est son nom, meilleur que `CBORTag`. Ça se règle en 4.0 par un renommage de `CBORTag` avec `class_alias` de transition, pas en gardant deux classes concurrentes sur le même numéro de tag.

## Changements

- `@deprecated since 3.3.5 … Will be removed in 4.0.0` sur `SelfDescribeCBORTag`, avec l'explication de la collision et le chemin de migration (`getCBORObject()` → `getValue()`). Annotation seule : le projet n'utilise ni `trigger_deprecation` ni `symfony/deprecation-contracts`, et je n'ajoute pas de dépendance pour ça. `phpstan-deprecation-rules` est actif mais n'analyse que `src`, où plus rien n'utilise la classe.
- Reprise de la docblock RFC 8949 § 3.4.6 sur `CBORTag`, qui n'en avait aucune.
- `doc/tags.md` ne documentait **que** `SelfDescribeCBORTag` pour le tag 55799 et pointait donc les utilisateurs vers la classe inatteignable au décodage. La section et le tableau récapitulatif passent à `CBORTag`, avec un encadré sur la dépréciation.

## Tests

Deux tests ajoutés à `SelfDescribeCBORTagTest`, qui verrouillent la sûreté du chemin de migration annoncé :

- les deux classes encodent le même contenu **octet pour octet** ;
- un `SelfDescribeCBORTag` encodé se relit bien en `CBORTag` et se normalise correctement.

Les tests existants de `SelfDescribeCBORTag` sont conservés : la classe reste fonctionnelle pendant la fenêtre de dépréciation.

## Vérifications locales

`castor phpunit` (645 tests, 1377 assertions), `castor ecs`, `castor phpstan`, `castor rector`, `castor deptrac` et `castor lint` passent tous.
