### PR TITLE
fix(tag): normalize tags to the value they encode

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -51,6 +51,10 @@ echo $dateTime->format('Y-m-d H:i:s'); // 2024-01-15 10:30:00
 **Accepts:** `TextStringObject` or `IndefiniteLengthTextStringObject`
 **Returns:** `DateTimeImmutable` when normalized
 
+A date-time that does not exist (`2013-02-30T12:00:00Z`, a twenty-fifth hour) is rejected with an
+`InvalidArgumentException` rather than silently rolled over to the following day. A leap second is accepted and
+reported as the instant that follows it, since PHP dates cannot hold one.
+
 ---
 
 #### Tag 1: Epoch-Based Date/Time
@@ -76,6 +80,9 @@ echo $dateTime->format('c'); // ISO 8601 format
 
 **Accepts:** `UnsignedIntegerObject`, `NegativeIntegerObject`, or float objects
 **Returns:** `DateTimeImmutable` when normalized
+
+A float timestamp is converted to the nearest microsecond. `NAN`, `INF` and magnitudes no date object can hold are
+rejected with an `InvalidArgumentException`.
 
 ---
 
@@ -104,6 +111,9 @@ $value = $tag->normalize(); // "81985529216486895"
 **Accepts:** `ByteStringObject` or `IndefiniteLengthByteStringObject`
 **Returns:** Numeric string when normalized
 
+An empty byte string is the preferred serialization of zero (RFC 8949 § 3.4.3): tag 2 normalizes it to `"0"`
+and tag 3 to `"-1"`.
+
 ---
 
 #### Tag 3: Negative Bignum
@@ -127,6 +137,9 @@ $value = $tag->normalize(); // "-256"
 
 **Accepts:** `ByteStringObject` or `IndefiniteLengthByteStringObject`
 **Returns:** Numeric string when normalized
+
+An empty byte string is the preferred serialization of zero (RFC 8949 § 3.4.3): tag 2 normalizes it to `"0"`
+and tag 3 to `"-1"`.
 
 ---
 
@@ -169,8 +182,8 @@ $tag = DecimalFractionTag::create(
 );
 ```
 
-**Accepts:** `ListObject` with exactly 2 elements [exponent, mantissa]
-**Returns:** String representation of the decimal value when normalized
+**Accepts:** `ListObject` or `IndefiniteLengthListObject` with exactly 2 elements [exponent, mantissa]
+**Returns:** Exact string representation of the decimal value when normalized
 
 ---
 

--- a/src/Tag/BigFloatTag.php
+++ b/src/Tag/BigFloatTag.php
@@ -6,6 +6,7 @@ namespace CBOR\Tag;
 
 use Brick\Math\BigInteger;
 use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
 use CBOR\ListObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\Normalizable;
@@ -16,6 +17,7 @@ use function extension_loaded;
 use InvalidArgumentException;
 use RuntimeException;
 use function sprintf;
+use function str_contains;
 
 final class BigFloatTag extends Tag implements Normalizable
 {
@@ -35,7 +37,8 @@ final class BigFloatTag extends Tag implements Normalizable
             throw new RuntimeException('The extension "bcmath" is required to use this tag');
         }
 
-        if (! $object instanceof ListObject || count($object) !== 2) {
+        $isList = $object instanceof ListObject || $object instanceof IndefiniteLengthListObject;
+        if (! $isList || count($object) !== 2) {
             throw new InvalidArgumentException(
                 'This tag only accepts a ListObject object that contains an exponent and a mantissa.'
             );
@@ -164,7 +167,7 @@ final class BigFloatTag extends Tag implements Normalizable
 
     public function normalize()
     {
-        /** @var ListObject $object */
+        /** @var ListObject|IndefiniteLengthListObject $object */
         $object = $this->object;
         /** @var UnsignedIntegerObject|NegativeIntegerObject $e */
         $e = $object->get(0);
@@ -173,8 +176,34 @@ final class BigFloatTag extends Tag implements Normalizable
 
         $exponent = (string) $e->normalize();
         self::assertExponentIsWithinBounds($exponent);
+        $mantissa = (string) $m->normalize();
 
-        return rtrim(bcmul((string) $m->normalize(), bcpow('2', $exponent, 100), 100), '0');
+        // The exponent is bounded, so it fits a PHP integer and the scale below is finite.
+        $exponentValue = (int) $exponent;
+        if ($exponentValue >= 0) {
+            // m x 2^e with e >= 0 is an integer: no scale is needed and none shall be printed.
+            return bcmul($mantissa, bcpow('2', $exponent, 0), 0);
+        }
+
+        // 2^-s is 5^s x 10^-s, so the exact quotient has s decimal digits and that scale loses nothing. A fixed
+        // scale would either truncate the result to zero or, worse, report a rounded value as the decoded one.
+        $scale = -$exponentValue;
+
+        return self::stripTrailingZeros(bcdiv($mantissa, bcpow('2', (string) $scale, 0), $scale));
+    }
+
+    /**
+     * bcdiv() pads the result up to the requested scale, so the exact value comes back with trailing zeros and,
+     * once they are gone, a dangling decimal point. Both are stripped, but only from a value that has a decimal
+     * point at all: trimming "512" would turn it into "51".
+     */
+    private static function stripTrailingZeros(string $value): string
+    {
+        if (! str_contains($value, '.')) {
+            return $value;
+        }
+
+        return rtrim(rtrim($value, '0'), '.');
     }
 
     private static function assertExponentIsWithinBounds(string $exponent): void

--- a/src/Tag/DatetimeTag.php
+++ b/src/Tag/DatetimeTag.php
@@ -10,9 +10,11 @@ use CBOR\Normalizable;
 use CBOR\Tag;
 use CBOR\TextStringObject;
 use const DATE_RFC3339;
+use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use InvalidArgumentException;
+use function preg_match;
 
 /**
  * @see \CBOR\Test\Tag\DatetimeTagTest
@@ -48,16 +50,38 @@ final class DatetimeTag extends Tag implements Normalizable
     {
         /** @var TextStringObject|IndefiniteLengthTextStringObject $object */
         $object = $this->object;
-        $result = DateTimeImmutable::createFromFormat(DATE_RFC3339, $object->normalize());
-        if ($result !== false) {
-            return $result;
+        $value = $object->normalize();
+
+        // RFC 3339 allows a leap second, which no PHP date can hold. It is parsed as the second before it and
+        // shifted forward again, which lands on the next minute: the closest instant this library can return.
+        $isLeapSecond = preg_match('/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:)60(.*)$/', $value, $matches) === 1;
+        if ($isLeapSecond) {
+            $value = $matches[1] . '59' . $matches[2];
         }
 
-        $formatted = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $object->normalize());
-        if ($formatted === false) {
-            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+        $result = DateTimeImmutable::createFromFormat(DATE_RFC3339, $value);
+        if ($result === false || ! self::wasParsedExactly()) {
+            $result = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $value);
+            if ($result === false || ! self::wasParsedExactly()) {
+                throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+            }
         }
 
-        return $formatted;
+        return $isLeapSecond ? $result->add(new DateInterval('PT1S')) : $result;
+    }
+
+    /**
+     * Tells whether the last parse consumed the whole string and described an instant that exists.
+     *
+     * createFromFormat() does not reject a date-time that cannot be: it rolls it over and merely reports a warning,
+     * so "2013-02-30" comes back as the 2nd of March and hour 25 as the next day. A document then decodes to an
+     * instant it does not carry, which is worse than a rejection.
+     */
+    private static function wasParsedExactly(): bool
+    {
+        $errors = DateTimeImmutable::getLastErrors();
+
+        // As of PHP 8.2 a parse with nothing to report returns false instead of an array of empty counters.
+        return $errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0);
     }
 }

--- a/src/Tag/DecimalFractionTag.php
+++ b/src/Tag/DecimalFractionTag.php
@@ -7,6 +7,7 @@ namespace CBOR\Tag;
 use Brick\Math\BigInteger;
 use CBOR\ByteStringObject;
 use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
 use CBOR\ListObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\Normalizable;
@@ -17,6 +18,7 @@ use function extension_loaded;
 use InvalidArgumentException;
 use RuntimeException;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strlen;
 
@@ -37,7 +39,8 @@ final class DecimalFractionTag extends Tag implements Normalizable
         if (! extension_loaded('bcmath')) {
             throw new RuntimeException('The extension "bcmath" is required to use this tag');
         }
-        if (! $object instanceof ListObject || count($object) !== 2) {
+        $isList = $object instanceof ListObject || $object instanceof IndefiniteLengthListObject;
+        if (! $isList || count($object) !== 2) {
             throw new InvalidArgumentException(
                 'This tag only accepts a ListObject object that contains an exponent and a mantissa.'
             );
@@ -213,7 +216,7 @@ final class DecimalFractionTag extends Tag implements Normalizable
 
     public function normalize()
     {
-        /** @var ListObject $object */
+        /** @var ListObject|IndefiniteLengthListObject $object */
         $object = $this->object;
         /** @var UnsignedIntegerObject|NegativeIntegerObject $e */
         $e = $object->get(0);
@@ -222,8 +225,34 @@ final class DecimalFractionTag extends Tag implements Normalizable
 
         $exponent = (string) $e->normalize();
         self::assertExponentIsWithinBounds($exponent);
+        $mantissa = (string) $m->normalize();
 
-        return rtrim(bcmul((string) $m->normalize(), bcpow('10', $exponent, 100), 100), '0');
+        // The exponent is bounded, so it fits a PHP integer and the scale below is finite.
+        $exponentValue = (int) $exponent;
+        if ($exponentValue >= 0) {
+            // m x 10^e with e >= 0 is an integer: no scale is needed and none shall be printed.
+            return bcmul($mantissa, bcpow('10', $exponent, 0), 0);
+        }
+
+        // m x 10^-s has exactly s decimal digits, so that scale makes the division exact. A fixed scale would
+        // either truncate the result to zero or, worse, report a rounded value as if it were the decoded one.
+        $scale = -$exponentValue;
+
+        return self::stripTrailingZeros(bcdiv($mantissa, bcpow('10', (string) $scale, 0), $scale));
+    }
+
+    /**
+     * bcdiv() pads the result up to the requested scale, so the exact value comes back with trailing zeros and,
+     * once they are gone, a dangling decimal point. Both are stripped, but only from a value that has a decimal
+     * point at all: trimming "500" would turn it into "5".
+     */
+    private static function stripTrailingZeros(string $value): string
+    {
+        if (! str_contains($value, '.')) {
+            return $value;
+        }
+
+        return rtrim(rtrim($value, '0'), '.');
     }
 
     private static function assertExponentIsWithinBounds(string $exponent): void

--- a/src/Tag/NegativeBigIntegerTag.php
+++ b/src/Tag/NegativeBigIntegerTag.php
@@ -45,7 +45,10 @@ final class NegativeBigIntegerTag extends Tag implements Normalizable
     {
         /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
         $object = $this->object;
-        $integer = Utils::hexToBigInteger(bin2hex($object->getValue()));
+        $value = $object->getValue();
+        // RFC 8949 section 3.4.3: the empty byte string is the preferred serialization of zero, so tag 3 wrapping
+        // it is -1 - 0.
+        $integer = $value === '' ? BigInteger::zero() : Utils::hexToBigInteger(bin2hex($value));
         $minusOne = BigInteger::of(-1);
 
         return $minusOne->minus($integer)

--- a/src/Tag/TimestampTag.php
+++ b/src/Tag/TimestampTag.php
@@ -14,12 +14,24 @@ use CBOR\Tag;
 use CBOR\UnsignedIntegerObject;
 use DateTimeImmutable;
 use DateTimeInterface;
+use function floor;
 use InvalidArgumentException;
-use const STR_PAD_RIGHT;
-use function strlen;
+use function is_infinite;
+use function is_nan;
+use function round;
+use function sprintf;
 
 final class TimestampTag extends Tag implements Normalizable
 {
+    /**
+     * The largest magnitude accepted for a floating point timestamp.
+     *
+     * Beyond that, the instant cannot be represented: the seconds no longer fit a PHP integer, and a double has
+     * long since lost the resolution needed to tell one second from the next anyway. The bound is some 3 x 10^10
+     * years, far outside the range DateTimeImmutable itself supports.
+     */
+    private const MAXIMUM_TIMESTAMP_MAGNITUDE = 1.0e18;
+
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
         if (! $object instanceof UnsignedIntegerObject && ! $object instanceof NegativeIntegerObject && ! $object instanceof HalfPrecisionFloatObject && ! $object instanceof SinglePrecisionFloatObject && ! $object instanceof DoublePrecisionFloatObject) {
@@ -49,35 +61,44 @@ final class TimestampTag extends Tag implements Normalizable
     {
         $object = $this->object;
 
-        switch (true) {
-            case $object instanceof UnsignedIntegerObject:
-            case $object instanceof NegativeIntegerObject:
-                $formatted = DateTimeImmutable::createFromFormat('U', $object->normalize());
-
-                break;
-            case $object instanceof HalfPrecisionFloatObject:
-            case $object instanceof SinglePrecisionFloatObject:
-            case $object instanceof DoublePrecisionFloatObject:
-                $value = (string) $object->normalize();
-                $parts = explode('.', $value);
-                if (isset($parts[1])) {
-                    if (strlen($parts[1]) > 6) {
-                        $parts[1] = substr($parts[1], 0, 6);
-                    } else {
-                        $parts[1] = str_pad($parts[1], 6, '0', STR_PAD_RIGHT);
-                    }
-                }
-                $formatted = DateTimeImmutable::createFromFormat('U.u', implode('.', $parts));
-
-                break;
-            default:
-                throw new InvalidArgumentException('Unable to normalize the object');
-        }
+        $formatted = match (true) {
+            $object instanceof UnsignedIntegerObject, $object instanceof NegativeIntegerObject => DateTimeImmutable::createFromFormat('U', $object->normalize()),
+            $object instanceof HalfPrecisionFloatObject, $object instanceof SinglePrecisionFloatObject, $object instanceof DoublePrecisionFloatObject => DateTimeImmutable::createFromFormat('U.u', self::formatFloat($object->normalize())),
+            default => throw new InvalidArgumentException('Unable to normalize the object'),
+        };
 
         if ($formatted === false) {
             throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
         }
 
         return $formatted;
+    }
+
+    /**
+     * Splits a floating point timestamp into the seconds and microseconds that "U.u" expects.
+     *
+     * The value is decomposed arithmetically rather than printed and cut apart: the decimal representation of a
+     * double depends on the "precision" ini setting, it drops the fractional part of an integral value entirely
+     * -- "U.u" then rejects the result -- and, being the representation of a signed magnitude, it truncates
+     * towards zero where "U.u" needs the seconds floored.
+     */
+    private static function formatFloat(float $timestamp): string
+    {
+        if (is_nan($timestamp) || is_infinite($timestamp)) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+        }
+        if ($timestamp < -self::MAXIMUM_TIMESTAMP_MAGNITUDE || $timestamp > self::MAXIMUM_TIMESTAMP_MAGNITUDE) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+        }
+
+        $seconds = (int) floor($timestamp);
+        $microseconds = (int) round(($timestamp - $seconds) * 1000000);
+        // Rounding up from something like x.9999996 carries into the next second.
+        if ($microseconds === 1000000) {
+            ++$seconds;
+            $microseconds = 0;
+        }
+
+        return sprintf('%d.%06d', $seconds, $microseconds);
     }
 }

--- a/src/Tag/UnsignedBigIntegerTag.php
+++ b/src/Tag/UnsignedBigIntegerTag.php
@@ -44,7 +44,12 @@ final class UnsignedBigIntegerTag extends Tag implements Normalizable
     {
         /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
         $object = $this->object;
+        $value = $object->normalize();
+        if ($value === '') {
+            // RFC 8949 section 3.4.3: the empty byte string is the preferred serialization of zero.
+            return '0';
+        }
 
-        return Utils::hexToString($object->normalize());
+        return Utils::hexToString($value);
     }
 }

--- a/tests/BigNumTagTest.php
+++ b/tests/BigNumTagTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\ByteStringObject;
+use CBOR\StringStream;
+use CBOR\Tag\NegativeBigIntegerTag;
+use CBOR\Tag\UnsignedBigIntegerTag;
+use function hex2bin;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression tests for the empty big num payload reported in Spomky-Labs/cbor-php#151.
+ *
+ * RFC 8949 section 3.4.3 makes the empty byte string the preferred serialization of zero, so "c2 40" is 0 and
+ * "c3 40" is -1. Both used to be rejected, at normalize() and, when the big num was used as a map key, from
+ * decode() itself, while the equivalent leading zero forms were accepted.
+ *
+ * @internal
+ */
+final class BigNumTagTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function emptyBigNums(): iterable
+    {
+        // RFC 8949 section 3.4.3: the empty byte string is the preferred serialization of zero.
+        yield 'unsigned big num, tag 2' => ['c240', '0'];
+        yield 'negative big num, tag 3' => ['c340', '-1'];
+        // The leading zero forms were already accepted and shall keep their value.
+        yield 'unsigned big num, leading zero' => ['c24100', '0'];
+        yield 'negative big num, leading zero' => ['c34100', '-1'];
+    }
+
+    #[Test]
+    #[DataProvider('emptyBigNums')]
+    public function anEmptyBigNumIsZero(string $payload, string $expected): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($payload)))
+        ;
+
+        static::assertSame($expected, $object->normalize());
+    }
+
+    /**
+     * The map key path normalizes the key on its own, and used to reject the whole document because of it.
+     */
+    #[Test]
+    public function anEmptyBigNumIsAcceptedAsAMapKey(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('a2c2406161c3406162')))
+        ;
+
+        static::assertSame([
+            0 => 'a',
+            -1 => 'b',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function anEmptyBigNumIsNormalizedByTheTagItself(): void
+    {
+        $unsigned = UnsignedBigIntegerTag::create(ByteStringObject::create(''));
+        $negative = NegativeBigIntegerTag::create(ByteStringObject::create(''));
+
+        static::assertInstanceOf(UnsignedBigIntegerTag::class, $unsigned);
+        static::assertInstanceOf(NegativeBigIntegerTag::class, $negative);
+        static::assertSame('0', $unsigned->normalize());
+        static::assertSame('-1', $negative->normalize());
+    }
+}

--- a/tests/ExceptionContractTest.php
+++ b/tests/ExceptionContractTest.php
@@ -22,7 +22,9 @@ use Throwable;
  * them was an assert(), which is compiled out under the production default zend.assertions=-1.
  *
  * Every exception assertion in this test suite expects InvalidArgumentException, and that is what callers guard
- * against, so both paths must raise it too.
+ * against, so the header path must raise it too. The empty bignum is no longer an error at all: RFC 8949 section
+ * 3.4.3 makes the empty byte string the preferred serialization of zero, so the tags decode it (see
+ * \CBOR\Test\BigNumTagTest), while the hexadecimal helpers keep rejecting an empty argument.
  *
  * @internal
  */
@@ -53,30 +55,28 @@ final class ExceptionContractTest extends CBORTestCase
     }
 
     /**
-     * @return iterable<string, array{string}>
+     * @return iterable<string, array{string, string}>
      */
     public static function emptyBigNumPayloads(): iterable
     {
-        yield 'unsigned big num, tag 2' => ['c240'];
-        yield 'negative big num, tag 3' => ['c340'];
+        yield 'unsigned big num, tag 2' => ['c240', '0'];
+        yield 'negative big num, tag 3' => ['c340', '-1'];
     }
 
     /**
-     * This is the case the removed assert() was supposed to cover. Under zend.assertions=-1, which is the production
-     * default, the statement was gone at compile time and the empty string reached Brick\Math untouched.
+     * This is the case the removed assert() was supposed to cover: under zend.assertions=-1, which is the production
+     * default, the statement was gone at compile time and the empty string reached Brick\Math untouched. Nothing
+     * reaches Brick\Math any more, because the empty byte string is the preferred serialization of zero.
      */
     #[Test]
     #[DataProvider('emptyBigNumPayloads')]
-    public function anEmptyBigNumPayloadIsRejected(string $payload): void
+    public function anEmptyBigNumPayloadDecodesToItsValue(string $payload, string $expected): void
     {
         $object = $this->getDecoder()
             ->decode(StringStream::create((string) hex2bin($payload)))
         ;
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value shall not be empty.');
-
-        $object->normalize();
+        static::assertSame($expected, $object->normalize());
     }
 
     /**

--- a/tests/Tag/DatetimeTagTest.php
+++ b/tests/Tag/DatetimeTagTest.php
@@ -14,8 +14,12 @@ use CBOR\Tag\DatetimeTag;
 use CBOR\Tag\TimestampTag;
 use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
+use const INF;
 use InvalidArgumentException;
 use Iterator;
+use const NAN;
+use function pack;
+use const PHP_FLOAT_MAX;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -56,22 +60,29 @@ final class DatetimeTagTest extends TestCase
         static::assertEqualsWithDelta(-10.0, $tag->normalize()->format('U.u'), 0.00001);
     }
 
+    /**
+     * The half precision value is 0.333251953125, which is closer to 333252 than to 333251 microseconds.
+     */
     #[Test]
     public function createValidTimestampTagWithHalfPrecisionFloat(): void
     {
         $tag = TimestampTag::create(
             HalfPrecisionFloatObject::create(hex2bin(base_convert('0011010101010101', 2, 16)))
         );
-        static::assertSame('0.333251', $tag->normalize()->format('U.u'));
+        static::assertSame('0.333252', $tag->normalize()->format('U.u'));
     }
 
+    /**
+     * The single precision value is 0.9999999403953552, which rounds up to a whole second: the carry has to move
+     * to the seconds instead of overflowing the microseconds field.
+     */
     #[Test]
     public function createValidTimestampTagWithSinglePrecisionFloat(): void
     {
         $tag = TimestampTag::create(
             SinglePrecisionFloatObject::create(hex2bin(base_convert('00111111011111111111111111111111', 2, 16)))
         );
-        static::assertSame('0.999999', $tag->normalize()->format('U.u'));
+        static::assertSame('1.000000', $tag->normalize()->format('U.u'));
     }
 
     #[Test]
@@ -82,7 +93,121 @@ final class DatetimeTagTest extends TestCase
                 hex2bin(base_convert('0100000000001001001000011111101101010100010001000010110100011000', 2, 16))
             )
         );
-        static::assertSame('3.141592', $tag->normalize()->format('U.u'));
+        static::assertSame('3.141593', $tag->normalize()->format('U.u'));
+    }
+
+    /**
+     * @return Iterator<array{float, string}>
+     */
+    public static function getFloatTimestamps(): Iterator
+    {
+        // An integral float is a valid timestamp per RFC 8949 section 3.4.2. Cutting the decimal representation
+        // apart used to leave nothing after the point and "U.u" rejected the result outright.
+        yield [1700000000.0, '2023-11-14T22:13:20.000000'];
+        yield [1.0, '1970-01-01T00:00:01.000000'];
+        yield [0.0, '1970-01-01T00:00:00.000000'];
+        // The seconds have to be floored, not truncated towards zero, or a negative timestamp lands a second late.
+        yield [-1.5, '1969-12-31T23:59:58.500000'];
+        yield [-0.5, '1969-12-31T23:59:59.500000'];
+        yield [-1.0, '1969-12-31T23:59:59.000000'];
+        // The microseconds are computed, not read off a decimal representation whose length depends on the
+        // "precision" ini setting.
+        yield [1700000000.123456, '2023-11-14T22:13:20.123456'];
+        yield [0.7, '1970-01-01T00:00:00.700000'];
+        yield [1.0e-7, '1970-01-01T00:00:00.000000'];
+    }
+
+    #[DataProvider('getFloatTimestamps')]
+    #[Test]
+    public function createValidTimestampTagFromFloat(float $timestamp, string $expected): void
+    {
+        $tag = TimestampTag::create(DoublePrecisionFloatObject::create(self::encodeDouble($timestamp)));
+
+        static::assertSame($expected, $tag->normalize()->format('Y-m-d\TH:i:s.u'));
+    }
+
+    /**
+     * @return Iterator<array{float}>
+     */
+    public static function getUnrepresentableTimestamps(): Iterator
+    {
+        yield [NAN];
+        yield [INF];
+        yield [-INF];
+        // PHP_FLOAT_MAX seconds is not an instant any date object can hold; it used to be reported as
+        // 1970-01-01T00:00:01.797693.
+        yield [PHP_FLOAT_MAX];
+        yield [-PHP_FLOAT_MAX];
+    }
+
+    #[DataProvider('getUnrepresentableTimestamps')]
+    #[Test]
+    public function anUnrepresentableTimestampIsRejected(float $timestamp): void
+    {
+        $tag = TimestampTag::create(DoublePrecisionFloatObject::create(self::encodeDouble($timestamp)));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+
+        $tag->normalize();
+    }
+
+    /**
+     * @return Iterator<array{string}>
+     */
+    public static function getImpossibleDatetimes(): Iterator
+    {
+        // createFromFormat() rolls these over silently: the 30th of February became the 2nd of March, and the
+        // twenty-fifth hour the next day.
+        yield ['2013-02-30T12:00:00Z'];
+        yield ['2015-02-29T00:00:00Z'];
+        yield ['2003-12-13T25:00:00Z'];
+        yield ['2003-12-13T18:61:00Z'];
+        yield ['2003-13-01T18:30:02Z'];
+        yield ['2003-12-13T18:30:02Z and some trailing data'];
+    }
+
+    #[DataProvider('getImpossibleDatetimes')]
+    #[Test]
+    public function anImpossibleDatetimeIsRejected(string $datetime): void
+    {
+        $tag = DatetimeTag::create(TextStringObject::create($datetime));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+
+        $tag->normalize();
+    }
+
+    /**
+     * A leap second is valid RFC 3339 but has no PHP representation. It is reported as the instant that follows,
+     * which is what the rollover already did, rather than rejected along with the impossible dates.
+     */
+    #[Test]
+    public function aLeapSecondIsAccepted(): void
+    {
+        $tag = DatetimeTag::create(TextStringObject::create('2016-12-31T23:59:60Z'));
+
+        static::assertSame('2017-01-01T00:00:00.000000', $tag->normalize()->format('Y-m-d\TH:i:s.u'));
+    }
+
+    #[Test]
+    public function aLeapSecondWithAnImpossibleDateIsStillRejected(): void
+    {
+        $tag = DatetimeTag::create(TextStringObject::create('2016-12-32T23:59:60Z'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+
+        $tag->normalize();
+    }
+
+    /**
+     * Encodes a float the way a document carries it: eight bytes, most significant first.
+     */
+    private static function encodeDouble(float $value): string
+    {
+        return pack('E', $value);
     }
 
     public static function getDatetimes(): Iterator

--- a/tests/TagNormalizationTest.php
+++ b/tests/TagNormalizationTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use Brick\Math\BigInteger;
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\BigFloatTag;
+use CBOR\Tag\DecimalFractionTag;
+use CBOR\Tag\UnsignedBigIntegerTag;
+use CBOR\UnsignedIntegerObject;
+use function extension_loaded;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use function str_repeat;
+
+/**
+ * Regression tests for the tag normalization issues reported in Spomky-Labs/cbor-php#151.
+ *
+ * The decimal fraction (tag 4) and big float (tag 5) tags used to compute their value at a fixed bcmath scale of
+ * 100 digits, so an exponent below -100 underflowed to zero and a value such as 5([-101, 2^100]) -- which is
+ * exactly 0.5 -- came back as 0.4999...9366. The scale now follows the exponent, which makes every accepted value
+ * exact. Alongside it, an indefinite length array is now accepted as the content of both tags.
+ *
+ * @internal
+ */
+final class TagNormalizationTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function exactValues(): iterable
+    {
+        // Anything below 10^-100 used to be truncated to "0." by the fixed scale.
+        yield 'DecimalFraction 1 x 10^-101' => ['c482386401', '0.' . str_repeat('0', 100) . '1'];
+        yield 'DecimalFraction 100000 x 10^-105' => ['c48238681a000186a0', '0.' . str_repeat('0', 99) . '1'];
+        yield 'DecimalFraction 27315 x 10^-2' => ['c48221196ab3', '273.15'];
+        yield 'DecimalFraction 15 x 10^-2' => ['c482210f', '0.15'];
+        yield 'DecimalFraction -15 x 10^-2' => ['c482212e', '-0.15'];
+        yield 'BigFloat 3 x 2^-1' => ['c5822003', '1.5'];
+        yield 'BigFloat 1 x 2^-10' => ['c5822901', '0.0009765625'];
+        yield 'BigFloat -3 x 2^-2' => ['c5822122', '-0.75'];
+
+        // A result that happens to be an integer shall not carry a dangling decimal point.
+        yield 'DecimalFraction 5 x 10^2' => ['c4820205', '500'];
+        yield 'DecimalFraction 0 x 10^-2' => ['c4822100', '0'];
+        yield 'DecimalFraction 100000 x 10^-3' => ['c482221a000186a0', '100'];
+        yield 'BigFloat 3 x 2^2' => ['c5820203', '12'];
+        yield 'BigFloat 1 x 2^10' => ['c5820a01', '1024'];
+    }
+
+    #[Test]
+    #[DataProvider('exactValues')]
+    public function aTagIsNormalizedToItsExactValue(string $payload, string $expected): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($payload)))
+        ;
+
+        static::assertSame($expected, $object->normalize());
+    }
+
+    /**
+     * The case from the report: 2^100 x 2^-101 is exactly one half, yet the fixed scale reported a value that was
+     * neither the encoded one nor a rounding of it.
+     */
+    #[Test]
+    public function aBigFloatWithABigNumMantissaIsExact(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $tag = BigFloatTag::createFromExponentAndMantissa(
+            NegativeIntegerObject::create(-101),
+            self::bigNum('2', 100)
+        );
+
+        static::assertSame('0.5', $this->normalizeThroughTheDecoder($tag));
+    }
+
+    /**
+     * 10^120 x 10^-101 is 10^19, an integer well above the range of a PHP integer, which the fixed scale reported
+     * as zero.
+     */
+    #[Test]
+    public function aDecimalFractionWithABigNumMantissaIsExact(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $tag = DecimalFractionTag::createFromExponentAndMantissa(
+            NegativeIntegerObject::create(-101),
+            self::bigNum('10', 120)
+        );
+
+        static::assertSame('1' . str_repeat('0', 19), $this->normalizeThroughTheDecoder($tag));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function indefiniteLengthContents(): iterable
+    {
+        // c4 9f 21 19 6ab3 ff -- 4(_[-2, 27315]), a valid array of two integers.
+        yield 'DecimalFraction' => ['c49f21196ab3ff'];
+        yield 'BigFloat' => ['c59f2003ff'];
+    }
+
+    #[Test]
+    #[DataProvider('indefiniteLengthContents')]
+    public function anIndefiniteLengthArrayIsAcceptedAsContent(string $payload): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($payload)))
+        ;
+
+        static::assertIsString($object->normalize());
+    }
+
+    #[Test]
+    public function anIndefiniteLengthArrayIsNormalizedLikeADefiniteOne(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $content = IndefiniteLengthListObject::create(
+            NegativeIntegerObject::create(-2),
+            UnsignedIntegerObject::create(27315)
+        );
+
+        static::assertSame('273.15', DecimalFractionTag::create($content)->normalize());
+    }
+
+    /**
+     * An indefinite length array still has to hold exactly an exponent and a mantissa.
+     */
+    #[Test]
+    public function anIndefiniteLengthArrayOfTheWrongSizeIsRejected(): void
+    {
+        if (! extension_loaded('bcmath')) {
+            static::markTestSkipped('bcmath extension is required');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a ListObject object');
+
+        DecimalFractionTag::create(IndefiniteLengthListObject::create(UnsignedIntegerObject::create(1)));
+    }
+
+    /**
+     * Builds the big num tag holding base^power.
+     */
+    private static function bigNum(string $base, int $power): CBORObject
+    {
+        $value = BigInteger::of($base)
+            ->power($power)
+            ->toBytes(false)
+        ;
+
+        return UnsignedBigIntegerTag::create(ByteStringObject::create($value));
+    }
+
+    /**
+     * Encodes the tag and decodes it again, so that the value under test is the one a document would carry.
+     */
+    private function normalizeThroughTheDecoder(CBORObject $object): string
+    {
+        $decoded = $this->getDecoder()
+            ->decode(StringStream::create((string) $object))
+        ;
+
+        return $decoded->normalize();
+    }
+}


### PR DESCRIPTION
Closes #151.

Each `normalize()` implementation covered here reported a value the document does not carry, or rejected one it does. Every case below is reproduced by a test.

## Tags 4 and 5 — exact scale instead of a fixed one

`DecimalFractionTag` and `BigFloatTag` evaluated `bcpow`/`bcmul` at a scale hard-coded to 100 digits, so anything below 10^-100 underflowed even though `MAX_ABSOLUTE_EXPONENT` accepts it:

| payload | value | before | after |
| --- | --- | --- | --- |
| `4([-101, 1])` | 1e-101 | `"0."` | `"0.000…01"` |
| `4([-105, 100000])` | 1e-100 | `"0."` | `"0.000…01"` |
| `4([-101, 10^120])` | 10^19 | `"0."` | `"10000000000000000000"` |
| `5([-101, 2^100])` | exactly 0.5 | `"0.4999…9366"` | `"0.5"` |
| `4([2, 5])` | 500 | `"500."` | `"500"` |
| `4([-2, 0])` | 0 | `"0."` | `"0"` |

The scale now follows the exponent: a non-negative exponent gives an integer and needs none, and `m x b^-s` is exact at scale `s` for both bases (`2^-s` is `5^s x 10^-s`). Trailing zeros and the decimal point left behind are stripped, which also removes the dangling point integral results used to carry.

Both tags also accept an **indefinite-length array** as their content — `c4 9f 21 19 6ab3 ff` is a valid array of two integers and was rejected because only `ListObject` was allowed.

## Tag 1 — float timestamps decomposed arithmetically

The value was cast to a string and split on the decimal point, which is not the value:

| payload | before | after |
| --- | --- | --- |
| `1(1700000000.0)` | `InvalidArgumentException` (valid per RFC 8949 §3.4.2) | 2023-11-14T22:13:20.000000 |
| `1(-1.5)` | 1969-12-31T23:59:**59**.5 | 1969-12-31T23:59:**58**.5 |
| `1(1700000000.123456)` | `.123500` or `.123456`, depending on the `precision` ini | `.123456` |
| `1(PHP_FLOAT_MAX)` | 1970-01-01T00:00:01.797693 | `InvalidArgumentException` |
| `1(NAN)`, `1(INF)` | 1970-01-01T00:00:00 | `InvalidArgumentException` |

Seconds are floored, microseconds rounded from the remainder with the carry moving to the seconds.

⚠️ **Rounding the microseconds instead of truncating them shifts three existing expectations by one microsecond** (`DatetimeTagTest`): the half-precision 0.333251953 is closer to 333252 than to 333251, the double-precision π to 3.141593, and the single-precision 0.99999994 rounds up to a whole second. Truncation is the alternative, but it turns 0.7 into `.699999`.

## Tag 0 — a date-time that cannot be is rejected

`createFromFormat()` does not fail on an impossible date, it rolls it over and reports a warning. `2013-02-30T12:00:00Z` decoded to the 2nd of March, a twenty-fifth hour to the next day. Those now raise `InvalidArgumentException`, along with trailing data after the timestamp.

A **leap second** is valid RFC 3339 and no PHP date can hold one, so `2016-12-31T23:59:60Z` keeps its rollover to `2017-01-01T00:00:00` rather than joining the rejections.

## Tags 2 and 3 — the empty byte string is zero

RFC 8949 §3.4.3 makes the empty byte string the preferred serialization of zero, so `c2 40` is `0` and `c3 40` is `-1`. Both were rejected, at `normalize()` and — when the big num was a map key, whose normalization builds the array — from `decode()` itself, while the leading-zero forms `c2 41 00` / `c3 41 00` were accepted. The hexadecimal helpers in `Utils` keep rejecting an empty argument: an empty *hexadecimal string* still has no value, it is the *byte string* that has one. `ExceptionContractTest`, which codified the rejection, is updated accordingly.

## Compatibility

Bug fixes to values, so a caller reading one of the affected tags gets a different — correct — result. Three classes of input that used to be accepted now raise `InvalidArgumentException`: impossible date-times, trailing data after a tag 0 timestamp, and float timestamps that no date can represent. Three previously rejected classes are now accepted: integral float timestamps, empty big num payloads, and indefinite-length arrays in tags 4 and 5.

## Checks

`castor ecs`, `castor rector`, `castor phpstan`, `castor deptrac`, `castor lint` and `castor phpunit` (721 tests, 1533 assertions) all pass. Rector converted the `switch (true)` in `TimestampTag::normalize()` to a `match`, now that each branch is a single expression.
