### PR TITLE
perf(float): read IEEE 754 payloads with unpack() instead of brick/math

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: ../src/OtherObject/DoublePrecisionFloatObject.php
 
 		-
-			rawMessage: 'Parameter #1 $value of static method CBOR\Utils::binToBigInteger() expects string, string|null given.'
-			identifier: argument.type
-			count: 3
-			path: ../src/OtherObject/DoublePrecisionFloatObject.php
-
-		-
 			rawMessage: Binary operation "&" between mixed and 8388607 results in an error.
 			identifier: binaryOp.invalid
 			count: 1
@@ -49,21 +43,9 @@ parameters:
 			path: ../src/OtherObject/HalfPrecisionFloatObject.php
 
 		-
-			rawMessage: 'Parameter #1 $value of static method CBOR\Utils::binToBigInteger() expects string, string|null given.'
-			identifier: argument.type
-			count: 3
-			path: ../src/OtherObject/HalfPrecisionFloatObject.php
-
-		-
 			rawMessage: Cannot access offset 1 on array|false.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: ../src/OtherObject/SinglePrecisionFloatObject.php
-
-		-
-			rawMessage: 'Parameter #1 $value of static method CBOR\Utils::binToBigInteger() expects string, string|null given.'
-			identifier: argument.type
-			count: 3
 			path: ../src/OtherObject/SinglePrecisionFloatObject.php
 
 		-

--- a/src/OtherObject/DoublePrecisionFloatObject.php
+++ b/src/OtherObject/DoublePrecisionFloatObject.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace CBOR\OtherObject;
 
-use Brick\Math\BigInteger;
 use CBOR\Normalizable;
 use CBOR\OtherObject as Base;
-use CBOR\Utils;
-use const INF;
 use InvalidArgumentException;
-use const NAN;
 use function strlen;
 
 final class DoublePrecisionFloatObject extends Base implements Normalizable
 {
+    use FloatBitsTrait;
+
     public static function supportedAdditionalInformation(): array
     {
         return [self::OBJECT_DOUBLE_PRECISION_FLOAT];
@@ -49,46 +47,25 @@ final class DoublePrecisionFloatObject extends Base implements Normalizable
         return new self(self::OBJECT_DOUBLE_PRECISION_FLOAT, $value);
     }
 
-    public function normalize(): float|int
+    public function normalize(): float
     {
-        $exponent = $this->getExponent();
-        $mantissa = $this->getMantissa();
-        $sign = $this->getSign();
-
-        if ($exponent === 0) {
-            $val = $mantissa * 2 ** (-(1022 + 52));
-        } elseif ($exponent !== 0b11111111111) {
-            $val = ($mantissa + (1 << 52)) * 2 ** ($exponent - (1023 + 52));
-        } else {
-            $val = $mantissa === 0 ? INF : NAN;
-        }
-
-        return $sign * $val;
+        return $this->value('E');
     }
 
     public function getExponent(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->shiftedRight(52)->and(Utils::hexToBigInteger('7ff'))->toInt();
+        return $this->bits('J') >> 52 & 0b11111111111;
     }
 
     public function getMantissa(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->and(Utils::hexToBigInteger('fffffffffffff'))->toInt();
+        return $this->bits('J') & 0xFFFFFFFFFFFFF;
     }
 
     public function getSign(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-        $sign = Utils::binToBigInteger($data)->shiftedRight(63);
-
-        return $sign->isEqualTo(BigInteger::one()) ? -1 : 1;
+        // "J" is unpacked signed, so the sign bit of the binary64 payload is the sign of the PHP integer.
+        return $this->bits('J') < 0 ? -1 : 1;
     }
 
     private static function hex2binSafe(string $hex): string

--- a/src/OtherObject/FloatBitsTrait.php
+++ b/src/OtherObject/FloatBitsTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\OtherObject;
+
+use InvalidArgumentException;
+use function is_float;
+use function is_int;
+
+/**
+ * Reads the IEEE 754 payload of a float object as native machine values.
+ *
+ * CBOR stores floats big-endian, which is exactly what unpack() consumes: "E" and "G" hand back the binary64 and
+ * binary32 values themselves, and "J", "N" and "n" the raw bit pattern the sign, exponent and mantissa accessors sit
+ * on. Both used to go through brick/math, which cost six BigInteger allocations for every float normalized.
+ *
+ * @internal
+ */
+trait FloatBitsTrait
+{
+    /**
+     * The payload read as the floating point value it encodes.
+     */
+    private function value(string $format): float
+    {
+        return (float) $this->unpackPayload($format);
+    }
+
+    /**
+     * The payload read as its raw bit pattern, big-endian.
+     */
+    private function bits(string $format): int
+    {
+        return (int) $this->unpackPayload($format);
+    }
+
+    private function unpackPayload(string $format): int|float
+    {
+        $data = $this->data;
+        if ($data === null) {
+            throw new InvalidArgumentException('Invalid data');
+        }
+
+        $unpacked = unpack($format, $data);
+        if ($unpacked === false) {
+            throw new InvalidArgumentException('Invalid data');
+        }
+
+        $value = $unpacked[1];
+        if (! is_int($value) && ! is_float($value)) {
+            throw new InvalidArgumentException('Invalid data');
+        }
+
+        return $value;
+    }
+}

--- a/src/OtherObject/HalfPrecisionFloatObject.php
+++ b/src/OtherObject/HalfPrecisionFloatObject.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace CBOR\OtherObject;
 
-use Brick\Math\BigInteger;
 use CBOR\Normalizable;
 use CBOR\OtherObject as Base;
-use CBOR\Utils;
 use const INF;
 use InvalidArgumentException;
 use const NAN;
@@ -15,6 +13,8 @@ use function strlen;
 
 final class HalfPrecisionFloatObject extends Base implements Normalizable
 {
+    use FloatBitsTrait;
+
     public static function supportedAdditionalInformation(): array
     {
         return [self::OBJECT_HALF_PRECISION_FLOAT];
@@ -108,11 +108,14 @@ final class HalfPrecisionFloatObject extends Base implements Normalizable
         return new self(self::OBJECT_HALF_PRECISION_FLOAT, $value);
     }
 
-    public function normalize(): float|int
+    public function normalize(): float
     {
-        $exponent = $this->getExponent();
-        $mantissa = $this->getMantissa();
-        $sign = $this->getSign();
+        // PHP has no native binary16, so the value is still assembled by hand -- but from the raw bits rather than
+        // from three brick/math round trips.
+        $bits = $this->bits('n');
+        $exponent = $bits >> 10 & 0b11111;
+        $mantissa = $bits & 0b1111111111;
+        $sign = ($bits >> 15 & 1) === 1 ? -1 : 1;
 
         if ($exponent === 0) {
             $val = $mantissa * 2 ** (-24);
@@ -122,32 +125,22 @@ final class HalfPrecisionFloatObject extends Base implements Normalizable
             $val = $mantissa === 0 ? INF : NAN;
         }
 
-        return $sign * $val;
+        return (float) ($sign * $val);
     }
 
     public function getExponent(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->shiftedRight(10)->and(Utils::hexToBigInteger('1f'))->toInt();
+        return $this->bits('n') >> 10 & 0b11111;
     }
 
     public function getMantissa(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->and(Utils::hexToBigInteger('3ff'))->toInt();
+        return $this->bits('n') & 0b1111111111;
     }
 
     public function getSign(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-        $sign = Utils::binToBigInteger($data)->shiftedRight(15);
-
-        return $sign->isEqualTo(BigInteger::one()) ? -1 : 1;
+        return ($this->bits('n') >> 15 & 1) === 1 ? -1 : 1;
     }
 
     private static function hex2binSafe(string $hex): string

--- a/src/OtherObject/SinglePrecisionFloatObject.php
+++ b/src/OtherObject/SinglePrecisionFloatObject.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace CBOR\OtherObject;
 
-use Brick\Math\BigInteger;
 use CBOR\Normalizable;
 use CBOR\OtherObject as Base;
-use CBOR\Utils;
-use const INF;
 use InvalidArgumentException;
-use const NAN;
 use function strlen;
 
 final class SinglePrecisionFloatObject extends Base implements Normalizable
 {
+    use FloatBitsTrait;
+
     public static function supportedAdditionalInformation(): array
     {
         return [self::OBJECT_SINGLE_PRECISION_FLOAT];
@@ -49,46 +47,24 @@ final class SinglePrecisionFloatObject extends Base implements Normalizable
         return new self(self::OBJECT_SINGLE_PRECISION_FLOAT, $value);
     }
 
-    public function normalize(): float|int
+    public function normalize(): float
     {
-        $exponent = $this->getExponent();
-        $mantissa = $this->getMantissa();
-        $sign = $this->getSign();
-
-        if ($exponent === 0) {
-            $val = $mantissa * 2 ** (-(126 + 23));
-        } elseif ($exponent !== 0b11111111) {
-            $val = ($mantissa + (1 << 23)) * 2 ** ($exponent - (127 + 23));
-        } else {
-            $val = $mantissa === 0 ? INF : NAN;
-        }
-
-        return $sign * $val;
+        return $this->value('G');
     }
 
     public function getExponent(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->shiftedRight(23)->and(Utils::hexToBigInteger('ff'))->toInt();
+        return $this->bits('N') >> 23 & 0b11111111;
     }
 
     public function getMantissa(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-
-        return Utils::binToBigInteger($data)->and(Utils::hexToBigInteger('7fffff'))->toInt();
+        return $this->bits('N') & 0x7FFFFF;
     }
 
     public function getSign(): int
     {
-        $data = $this->data;
-        Utils::assertString($data, 'Invalid data');
-        $sign = Utils::binToBigInteger($data)->shiftedRight(31);
-
-        return $sign->isEqualTo(BigInteger::one()) ? -1 : 1;
+        return ($this->bits('N') >> 31 & 1) === 1 ? -1 : 1;
     }
 
     private static function hex2binSafe(string $hex): string

--- a/tests/FloatBitPatternTest.php
+++ b/tests/FloatBitPatternTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\OtherObject\DoublePrecisionFloatObject;
+use CBOR\OtherObject\HalfPrecisionFloatObject;
+use CBOR\OtherObject\SinglePrecisionFloatObject;
+use const INF;
+use function is_float;
+use Iterator;
+use const PHP_FLOAT_EPSILON;
+use const PHP_FLOAT_MAX;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use function sprintf;
+
+/**
+ * A float object shall normalize to the value its payload encodes, as a float, whatever its magnitude.
+ *
+ * normalize() used to assemble the value with `2 ** $shift`, which PHP evaluates to an *integer* whenever the shift
+ * is not negative. Every finite value large enough to reach that branch therefore came back as an int -- roughly one
+ * single-precision payload in six -- until the product grew past PHP_INT_MAX and silently became a float again.
+ *
+ * @internal
+ */
+final class FloatBitPatternTest extends CBORTestCase
+{
+    /**
+     * These magnitudes all sat in the band that used to normalize to an int.
+     */
+    #[DataProvider('getLargeValue')]
+    #[Test]
+    public function aLargeValueNormalizesToAFloat(string $class, string $payload, float $expected): void
+    {
+        /** @var DoublePrecisionFloatObject|HalfPrecisionFloatObject|SinglePrecisionFloatObject $object */
+        $object = $class::create(hex2bin($payload));
+        $normalized = $object->normalize();
+
+        static::assertIsFloat($normalized);
+        static::assertSame($expected, $normalized);
+    }
+
+    public static function getLargeValue(): Iterator
+    {
+        yield 'half 1024' => [HalfPrecisionFloatObject::class, '6400', 1024.0];
+        yield 'half 2047' => [HalfPrecisionFloatObject::class, '67ff', 2047.0];
+        yield 'single 2^23' => [SinglePrecisionFloatObject::class, '4b000000', 8_388_608.0];
+        yield 'single 2^24-1' => [SinglePrecisionFloatObject::class, '4b7fffff', 16_777_215.0];
+        yield 'double 2^52' => [DoublePrecisionFloatObject::class, '4330000000000000', 4_503_599_627_370_496.0];
+        yield 'double 2^53-1' => [
+            DoublePrecisionFloatObject::class,
+            '433fffffffffffff',
+            9_007_199_254_740_991.0,
+        ];
+    }
+
+    /**
+     * Every exponent of the 16-bit format, both signs, across the mantissa range: the subnormal branch, the thirty
+     * normal ones and the infinity/NaN branch all have to yield a float.
+     */
+    #[Test]
+    public function everyHalfPrecisionExponentNormalizesToAFloat(): void
+    {
+        $offenders = [];
+        foreach (range(0, 31) as $exponent) {
+            foreach ([0, 1] as $sign) {
+                foreach ([0, 1, 341, 682, 1022, 1023] as $mantissa) {
+                    $bits = $sign << 15 | $exponent << 10 | $mantissa;
+                    $normalized = HalfPrecisionFloatObject::create(pack('n', $bits))->normalize();
+                    if (! is_float($normalized)) {
+                        $offenders[] = sprintf('0x%04x', $bits);
+                    }
+                }
+            }
+        }
+
+        static::assertSame([], $offenders);
+    }
+
+    #[DataProvider('getRoundTripValue')]
+    #[Test]
+    public function aDoublePrecisionValueSurvivesARoundTrip(float $value): void
+    {
+        static::assertSame($value, DoublePrecisionFloatObject::createFromFloat($value)->normalize());
+    }
+
+    public static function getRoundTripValue(): Iterator
+    {
+        yield 'zero' => [0.0];
+        yield 'negative zero' => [-0.0];
+        yield 'one' => [1.0];
+        yield 'minus one' => [-1.0];
+        yield 'fraction' => [0.123456789012345];
+        yield 'epsilon' => [PHP_FLOAT_EPSILON];
+        yield 'max' => [PHP_FLOAT_MAX];
+        yield 'smallest subnormal' => [4.9406564584124654e-324];
+        yield 'largest subnormal' => [2.2250738585072009e-308];
+        yield 'two to the 52' => [4_503_599_627_370_496.0];
+        yield 'two to the 53' => [9_007_199_254_740_992.0];
+        yield 'large' => [1.0e300];
+    }
+
+    /**
+     * Negative zero has the same magnitude as zero and only the sign bit tells them apart.
+     */
+    #[Test]
+    public function negativeZeroKeepsItsSign(): void
+    {
+        $normalized = DoublePrecisionFloatObject::create(hex2bin('8000000000000000'))->normalize();
+
+        static::assertSame(0.0, abs($normalized));
+        // fdiv() rather than "/", which raises DivisionByZeroError: the sign is what separates -0.0 from 0.0.
+        static::assertSame(-INF, fdiv(1.0, $normalized));
+    }
+
+    #[DataProvider('getBitPattern')]
+    #[Test]
+    public function theAccessorsReportTheBitPattern(
+        string $class,
+        string $payload,
+        int $sign,
+        int $exponent,
+        int $mantissa
+    ): void {
+        /** @var DoublePrecisionFloatObject|HalfPrecisionFloatObject|SinglePrecisionFloatObject $object */
+        $object = $class::create(hex2bin($payload));
+
+        static::assertSame($sign, $object->getSign());
+        static::assertSame($exponent, $object->getExponent());
+        static::assertSame($mantissa, $object->getMantissa());
+    }
+
+    public static function getBitPattern(): Iterator
+    {
+        yield 'half -2' => [HalfPrecisionFloatObject::class, 'c000', -1, 16, 0];
+        yield 'half largest' => [HalfPrecisionFloatObject::class, '7bff', 1, 30, 1023];
+        yield 'single -2' => [SinglePrecisionFloatObject::class, 'c0000000', -1, 128, 0];
+        yield 'single largest' => [SinglePrecisionFloatObject::class, '7f7fffff', 1, 254, 8_388_607];
+        yield 'double 1.0' => [DoublePrecisionFloatObject::class, '3ff0000000000000', 1, 1023, 0];
+        yield 'double -2.0' => [DoublePrecisionFloatObject::class, 'c000000000000000', -1, 1024, 0];
+        yield 'double largest' => [
+            DoublePrecisionFloatObject::class,
+            '7fefffffffffffff',
+            1,
+            2046,
+            4_503_599_627_370_495,
+        ];
+        yield 'double negative NaN' => [DoublePrecisionFloatObject::class, 'fff8000000000000', -1, 2047, 1 << 51];
+    }
+}


### PR DESCRIPTION
Follow-up to #155, same origin: profiling the GLD.SerializerBenchmark suite (#148) after the integer fix showed that deserialization had become dominated by floats.

## The cost

`normalize()` reached the payload through `getExponent()`, `getMantissa()` and `getSign()`. Each rebuilt a `BigInteger` from the raw bytes *and* another one from its own hexadecimal mask — six allocations for every single value:

```php
return Utils::binToBigInteger($data)->shiftedRight(52)->and(Utils::hexToBigInteger('7ff'))->toInt();
```

CBOR stores floats big-endian, which is exactly what `unpack()` consumes: `E` and `G` hand back the binary64 and binary32 values themselves, `n`/`N`/`J` the raw bit pattern the accessors sit on.

| | before | after |
|---|---|---|
| normalize 3200 doubles | 50 943 µs | 984 µs |

## Effect on the benchmark

Running the suite's `cbor` row (real cells, real `DataV2` fixtures, bytes mode, min of 60 reps):

| | before | after |
|---|---|---|
| deserialization, all 10 cells | ~99 ms | **~46 ms** |
| `telemetry` N=100 (3200 doubles) | 62.2 ms | 9.9 ms |
| serialization | unchanged | unchanged |

`FidelityScore` stays 1.0 on every cell. Serialization is untouched — `createFromFloat()` already used `pack()`.

## Behaviour change: normalize() now always returns a float

Worth a deliberate look, because it is not purely a performance change.

The old code assembled the value as `($mantissa + (1 << 52)) * 2 ** ($exponent - 1075)`. PHP evaluates `2 ** $n` to an **integer** whenever `$n >= 0`, so the whole product became an integer for every finite value large enough to reach that branch — and then silently reverted to a float once it passed `PHP_INT_MAX`. That is what the `float|int` return type was describing.

Measured over random payloads, the old code returned an `int` for **15.7% of single-precision** and 0.5% of double-precision values. A `DoublePrecisionFloatObject` yielding a PHP `int` depending on magnitude is not something a caller can reasonably rely on, so I treated it as a defect rather than preserving it. The return type is narrowed from `float|int` to `float`, which is covariant and legal here (both classes are `final`, and `Normalizable::normalize()` declares no return type).

One consequence worth naming: a double in `[2^52, 2^53)` used as a map key used to normalize to an int and was therefore *accepted* as a key. It is now rejected like every other float key. That is consistent, but it is a change.

If you would rather keep the old typing, say so and I will restore it — it is one cast.

## Verification

The values themselves are unchanged. I compared the new implementation against the previous algorithm over:

- **all 65 536 half-precision bit patterns** — 0 discrepancies, values and all three accessors;
- **200 000 random single-precision** and **200 000 random double-precision** patterns — 0 discrepancies.

Edge cases covered by the new `tests/FloatBitPatternTest.php`: ±0 (including that `-0.0` keeps its sign), ±INF, NaN, smallest and largest subnormals, `PHP_FLOAT_EPSILON`, `PHP_FLOAT_MAX`, and the magnitudes that used to normalize to an int.

683 tests pass (up from 655); no existing test needed changing. `castor phpstan`, `ecs`, `rector`, `lint` and `deptrac` are clean.
