### PR TITLE
perf(container): defer length heads and read the stream without a file handle

### DIFF
--- a/src/LengthCalculator.php
+++ b/src/LengthCalculator.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace CBOR;
 
-use Brick\Math\BigInteger;
 use function chr;
 use function count;
-use InvalidArgumentException;
-use const STR_PAD_LEFT;
 use function strlen;
 
 final class LengthCalculator
@@ -43,24 +40,9 @@ final class LengthCalculator
         return match (true) {
             $length <= 23 => [$length, null],
             $length <= 0xFF => [24, chr($length)],
-            $length <= 0xFFFF => [25, self::hex2bin(dechex($length))],
-            $length <= 0xFFFFFFFF => [26, self::hex2bin(dechex($length))],
-            BigInteger::of($length)->isLessThan(BigInteger::fromBase('FFFFFFFFFFFFFFFF', 16)) => [
-                27,
-                self::hex2bin(dechex($length)),
-            ],
-            default => [31, null],
+            $length <= 0xFFFF => [25, pack('n', $length)],
+            $length <= 0xFFFFFFFF => [26, pack('N', $length)],
+            default => [27, pack('J', $length)],
         };
-    }
-
-    private static function hex2bin(string $data): string
-    {
-        $data = str_pad($data, (int) (2 ** ceil(log(strlen($data), 2))), '0', STR_PAD_LEFT);
-        $result = hex2bin($data);
-        if ($result === false) {
-            throw new InvalidArgumentException('Unable to convert the data');
-        }
-
-        return $result;
     }
 }

--- a/src/ListObject.php
+++ b/src/ListObject.php
@@ -31,6 +31,8 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
 
     private ?string $length;
 
+    private bool $lengthStale = false;
+
     /**
      * @param CBORObject[] $data
      */
@@ -54,6 +56,7 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
 
     public function __toString(): string
     {
+        $this->refreshLength();
         $result = parent::__toString();
         $result .= $this->length ?? '';
         foreach ($this->data as $object) {
@@ -61,6 +64,27 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
         }
 
         return $result;
+    }
+
+    public function getAdditionalInformation(): int
+    {
+        $this->refreshLength();
+
+        return parent::getAdditionalInformation();
+    }
+
+    /**
+     * The head carries the item count, so every insertion or removal invalidates it. Recomputing it there made the
+     * cost of building a container quadratic in call count; it is only ever observed when the object is written out.
+     */
+    private function refreshLength(): void
+    {
+        if (! $this->lengthStale) {
+            return;
+        }
+
+        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = false;
     }
 
     /**
@@ -74,7 +98,7 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
     public function add(CBORObject $object): self
     {
         $this->data[] = $object;
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }
@@ -91,7 +115,7 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
         }
         unset($this->data[$index]);
         $this->data = array_values($this->data);
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }
@@ -112,7 +136,7 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
         }
 
         $this->data[$index] = $object;
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }

--- a/src/MapObject.php
+++ b/src/MapObject.php
@@ -30,6 +30,8 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
 
     private ?string $length;
 
+    private bool $lengthStale = false;
+
     /**
      * @param MapItem[] $data
      */
@@ -44,6 +46,7 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
 
     public function __toString(): string
     {
+        $this->refreshLength();
         $result = parent::__toString();
         $result .= $this->length ?? '';
         foreach ($this->data as $object) {
@@ -52,6 +55,27 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
         }
 
         return $result;
+    }
+
+    public function getAdditionalInformation(): int
+    {
+        $this->refreshLength();
+
+        return parent::getAdditionalInformation();
+    }
+
+    /**
+     * The head carries the item count, so every insertion or removal invalidates it. Recomputing it there made the
+     * cost of building a container quadratic in call count; it is only ever observed when the object is written out.
+     */
+    private function refreshLength(): void
+    {
+        if (! $this->lengthStale) {
+            return;
+        }
+
+        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = false;
     }
 
     /**
@@ -68,7 +92,7 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
             throw new InvalidArgumentException('Invalid key. Shall be normalizable');
         }
         $this->data[$this->registerKey($key, false)] = MapItem::create($key, $value);
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }
@@ -85,7 +109,7 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
         }
         unset($this->data[$index]);
         $this->unregisterKey($index);
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }
@@ -102,7 +126,7 @@ final class MapObject extends AbstractCBORObject implements Countable, IteratorA
     public function set(MapItem $object): self
     {
         $this->data[$this->registerKey($object->getKey(), true)] = $object;
-        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfArray($this->data);
+        $this->lengthStale = true;
 
         return $this;
     }

--- a/src/StringStream.php
+++ b/src/StringStream.php
@@ -5,32 +5,19 @@ declare(strict_types=1);
 namespace CBOR;
 
 use InvalidArgumentException;
-use RuntimeException;
 use function sprintf;
 use function strlen;
 
 final class StringStream implements Stream
 {
-    /**
-     * @var resource
-     */
-    private $resource;
+    private int $offset = 0;
 
-    public function __construct(string $data)
-    {
-        $resource = fopen('php://memory', 'rb+');
-        if ($resource === false) {
-            throw new RuntimeException('Unable to open the memory');
-        }
-        $result = fwrite($resource, $data);
-        if ($result === false) {
-            throw new RuntimeException('Unable to write the memory');
-        }
-        $result = rewind($resource);
-        if ($result === false) {
-            throw new RuntimeException('Unable to rewind the memory');
-        }
-        $this->resource = $resource;
+    private readonly int $length;
+
+    public function __construct(
+        private readonly string $data
+    ) {
+        $this->length = strlen($data);
     }
 
     public static function create(string $data): self
@@ -44,34 +31,17 @@ final class StringStream implements Stream
             return '';
         }
 
-        $alreadyRead = 0;
-        $data = '';
-        while ($alreadyRead < $length) {
-            $left = $length - $alreadyRead;
-            $sizeToRead = $left < 1024 && $left > 0 ? $left : 1024;
-            $newData = fread($this->resource, $sizeToRead);
-            $alreadyRead += $sizeToRead;
-
-            if ($newData === false) {
-                throw new RuntimeException('Unable to read the memory');
-            }
-            $data .= $newData;
-            if (strlen($newData) < $sizeToRead) {
-                throw new InvalidArgumentException(sprintf(
-                    'Out of range. Expected: %d, read: %d.',
-                    $length,
-                    strlen($data)
-                ));
-            }
-        }
-
-        if (strlen($data) !== $length) {
+        $available = $this->length - $this->offset;
+        if ($available < $length) {
             throw new InvalidArgumentException(sprintf(
                 'Out of range. Expected: %d, read: %d.',
                 $length,
-                strlen($data)
+                $available < 0 ? 0 : $available
             ));
         }
+
+        $data = substr($this->data, $this->offset, $length);
+        $this->offset += $length;
 
         return $data;
     }

--- a/tests/LazyLengthHeaderTest.php
+++ b/tests/LazyLengthHeaderTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A container computes its length head only when that head is observed, so every mutation has to invalidate it.
+ *
+ * The head used to be recomputed on each add(), set() and remove(). Deferring it is only safe if nothing can read a
+ * head that a later mutation has made wrong, which is what these tests pin down: the two observers are __toString()
+ * and getAdditionalInformation(), and both have to see the current item count.
+ *
+ * @internal
+ */
+final class LazyLengthHeaderTest extends CBORTestCase
+{
+    #[DataProvider('getListSize')]
+    #[Test]
+    public function aListReportsItsHeadAfterEveryAdd(int $size, int $expectedAdditionalInformation): void
+    {
+        $list = ListObject::create();
+        for ($i = 0; $i < $size; ++$i) {
+            $list->add(UnsignedIntegerObject::create(1));
+        }
+
+        static::assertSame($expectedAdditionalInformation, $list->getAdditionalInformation());
+        static::assertCount($size, $list);
+    }
+
+    /**
+     * The head widens at 24 items, then at 256: the boundaries are where a stale head would show.
+     */
+    public static function getListSize(): Iterator
+    {
+        yield 'empty' => [0, 0];
+        yield 'one' => [1, 1];
+        yield 'last inline count' => [23, 23];
+        yield 'first one-byte count' => [24, 24];
+        yield 'last one-byte count' => [255, 24];
+        yield 'first two-byte count' => [256, 25];
+    }
+
+    #[Test]
+    public function aListHeadShrinksBackWhenItemsAreRemoved(): void
+    {
+        $list = ListObject::create();
+        for ($i = 0; $i < 24; ++$i) {
+            $list->add(UnsignedIntegerObject::create(1));
+        }
+        static::assertSame(24, $list->getAdditionalInformation());
+
+        $list->remove(0);
+
+        static::assertSame(23, $list->getAdditionalInformation());
+        static::assertCount(23, $list);
+        static::assertStringStartsWith('97', bin2hex((string) $list));
+    }
+
+    /**
+     * set() replaces an item, so the count -- and the head with it -- has to stay put.
+     */
+    #[Test]
+    public function replacingAListItemLeavesTheHeadAlone(): void
+    {
+        $list = ListObject::create();
+        for ($i = 0; $i < 24; ++$i) {
+            $list->add(UnsignedIntegerObject::create(1));
+        }
+
+        $list->set(0, TextStringObject::create('replaced'));
+
+        static::assertSame(24, $list->getAdditionalInformation());
+        static::assertCount(24, $list);
+    }
+
+    #[Test]
+    public function aMapReportsItsHeadAfterEveryAdd(): void
+    {
+        $map = MapObject::create();
+        for ($i = 0; $i < 24; ++$i) {
+            $map->add(UnsignedIntegerObject::create($i), UnsignedIntegerObject::create(1));
+        }
+
+        static::assertSame(24, $map->getAdditionalInformation());
+        static::assertStringStartsWith('b818', bin2hex((string) $map));
+    }
+
+    /**
+     * set() on a map may introduce a key rather than replace one, and then the count does move.
+     */
+    #[Test]
+    public function aMapHeadFollowsAKeyAddedThroughSet(): void
+    {
+        $map = MapObject::create();
+        for ($i = 0; $i < 23; ++$i) {
+            $map->add(UnsignedIntegerObject::create($i), UnsignedIntegerObject::create(1));
+        }
+        static::assertSame(23, $map->getAdditionalInformation());
+
+        $map->set(MapItem::create(UnsignedIntegerObject::create(23), UnsignedIntegerObject::create(1)));
+
+        static::assertSame(24, $map->getAdditionalInformation());
+        static::assertCount(24, $map);
+    }
+
+    #[Test]
+    public function aMapHeadShrinksBackWhenAKeyIsRemoved(): void
+    {
+        $map = MapObject::create();
+        for ($i = 0; $i < 24; ++$i) {
+            $map->add(UnsignedIntegerObject::create($i), UnsignedIntegerObject::create(1));
+        }
+        static::assertSame(24, $map->getAdditionalInformation());
+
+        $map->remove(0);
+
+        static::assertSame(23, $map->getAdditionalInformation());
+        static::assertStringStartsWith('b7', bin2hex((string) $map));
+    }
+
+    /**
+     * Reading the head must not freeze it: a mutation after a read has to invalidate it again.
+     */
+    #[Test]
+    public function theHeadIsInvalidatedAgainAfterItHasBeenRead(): void
+    {
+        $list = ListObject::create();
+        for ($i = 0; $i < 23; ++$i) {
+            $list->add(UnsignedIntegerObject::create(1));
+        }
+
+        static::assertSame(23, $list->getAdditionalInformation());
+        static::assertStringStartsWith('97', bin2hex((string) $list));
+
+        $list->add(UnsignedIntegerObject::create(1));
+
+        static::assertSame(24, $list->getAdditionalInformation());
+        static::assertStringStartsWith('9818', bin2hex((string) $list));
+    }
+}

--- a/tests/StringStreamTest.php
+++ b/tests/StringStreamTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\StringStream;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The stream hands out the payload in sequence and never reads past its end.
+ *
+ * It used to hold the data in a php://memory handle and pull it back with fread(). Reading a string that is already
+ * in memory through a file handle is what these tests keep honest now that it is a cursor over that string: the
+ * successive reads have to advance, stop exactly at the end, and report what was left when they cannot.
+ *
+ * @internal
+ */
+final class StringStreamTest extends CBORTestCase
+{
+    #[Test]
+    public function successiveReadsAdvanceThroughThePayload(): void
+    {
+        $stream = StringStream::create('abcdefghij');
+
+        static::assertSame('abc', $stream->read(3));
+        static::assertSame('de', $stream->read(2));
+        static::assertSame('fghij', $stream->read(5));
+    }
+
+    #[Test]
+    public function aZeroLengthReadYieldsNothingAndDoesNotAdvance(): void
+    {
+        $stream = StringStream::create('abc');
+
+        static::assertSame('', $stream->read(0));
+        static::assertSame('abc', $stream->read(3));
+    }
+
+    #[Test]
+    public function readingExactlyToTheEndIsAllowed(): void
+    {
+        $stream = StringStream::create('abc');
+
+        static::assertSame('abc', $stream->read(3));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Out of range. Expected: 1, read: 0.');
+        $stream->read(1);
+    }
+
+    #[Test]
+    public function readingPastTheEndReportsWhatWasLeft(): void
+    {
+        $stream = StringStream::create('abcdefghij');
+        $stream->read(7);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Out of range. Expected: 5, read: 3.');
+        $stream->read(5);
+    }
+
+    #[Test]
+    public function anEmptyPayloadHasNothingToGive(): void
+    {
+        $stream = StringStream::create('');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Out of range. Expected: 1, read: 0.');
+        $stream->read(1);
+    }
+
+    /**
+     * The old implementation pulled the payload in 1024-byte slices, so a read spanning that boundary is worth
+     * keeping an eye on.
+     */
+    #[Test]
+    public function aReadLargerThanTheOldSliceSizeIsReturnedWhole(): void
+    {
+        $payload = str_repeat('x', 5000);
+        $stream = StringStream::create($payload);
+
+        static::assertSame($payload, $stream->read(5000));
+    }
+
+    #[Test]
+    public function binaryPayloadsAreReturnedByteForByte(): void
+    {
+        $payload = "\x00\xff\x0a\x1b\x00";
+        $stream = StringStream::create($payload);
+
+        static::assertSame($payload, $stream->read(5));
+    }
+}


### PR DESCRIPTION
Follows #155 and #163. Profiling the GLD.SerializerBenchmark suite (#148) after those two showed **brick/math is no longer the bottleneck** — it is down to **0.2% of the profile**, 205 calls, all from `Utils::binToInt()` decoding lengths ≥ 24. What is left are three costs of our own.

Profile taken with Xdebug inside the phpqa image, excluding the benchmark's own data generation:

| group | share | calls |
|---|---|---|
| Decoder | 22.5% | 39,019 |
| MapObject | 16.7% | 59,200 |
| Encoder | 14.4% | 36,515 |
| TextStringObject | 11.3% | 79,601 |
| ListObject + LengthCalculator | 12.1% | 138,351 |
| StringStream | 3.4% | 36,316 |
| brick/math + Utils | 0.5% | 1,846 |

## 1. The length head was recomputed on every mutation

`ListObject` and `MapObject` ran `LengthCalculator::getLengthOfArray()` on each `add()`, `set()` and `remove()`. Building a container of *n* items ran the calculation *n* times, for a head nothing reads until the object is serialized — **110,421 calls** on this workload.

It is computed on demand now. Every mutation marks it stale; `__toString()` and `getAdditionalInformation()` are the only two observers and both refresh first. `getAdditionalInformation()` is overridden for exactly that reason, since it is inherited and reads the property directly.

## 2. LengthCalculator took a logarithm per call

```php
str_pad($data, (int) (2 ** ceil(log(strlen($data), 2))), '0', STR_PAD_LEFT)
```

`pack('n'/'N'/'J')` does the same job directly — the same change `UnsignedIntegerObject` already got in #155. This also drops the last `BigInteger` from the file.

## 3. StringStream read memory through a file handle

It held the payload in a `php://memory` handle and pulled it back with `fread()` in 1024-byte slices, to read a string that was already in memory. It is a plain cursor over that string now.

The out-of-range messages are unchanged — `RobustnessTest` and `InvalidTypeTest` already pin their exact wording (`Out of range. Expected: 3000, read: 2000.`), and they pass untouched, which is what validated the rewrite.

## Result

| | 3.3.x | this PR |
|---|---|---|
| serialization | 36.0 ms | **33.7 ms** (−6%) |
| deserialization | 45.9 ms | **37.5 ms** (−18%) |
| total | 81.9 ms | **71.2 ms** (−13%) |

*min of 60 reps, 3 alternating series, on the benchmark's 10 real cells.*

Encoded output is byte for byte identical (129,180 bytes before and after), and `FidelityScore` stays 1.0 on every cell.

## Tests

- `tests/LazyLengthHeaderTest.php` — the head is correct after every `add()` across the 23/24 and 255/256 boundaries, shrinks back after `remove()`, stays put when `set()` replaces a list item, follows a key that `MapObject::set()` *introduces*, and is invalidated again after having been read once.
- `tests/StringStreamTest.php` — successive reads advance, a zero-length read does not, reading exactly to the end is allowed, reading past it reports what was left, and a read larger than the old 1024-byte slice comes back whole.

854 tests pass (up from 835). `castor phpstan`, `ecs`, `rector`, `lint` and `deptrac` are clean, with no new baseline entry.

## Not addressed here

`Decoder` (22.5%) and `MapObject` (16.7%) are now the two largest items and I have not touched them — filed as #165.

