### PR TITLE
Implement the missing IANA registry tags

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			rawMessage: 'Method CBOR\ListObject::normalize() should return array<int, mixed> but returns array<mixed>.'
-			identifier: return.type
-			count: 1
-			path: ../src/ListObject.php
-
-		-
 			rawMessage: 'Method CBOR\NegativeIntegerObject::getValue() should return numeric-string but returns non-empty-string.'
 			identifier: return.type
 			count: 1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $data = $decoded->normalize();
 
 ### Quick Links
 
-- **[Tags Reference](doc/tags.md)** - Complete guide to all 15+ supported CBOR tags
+- **[Tags Reference](doc/tags.md)** - Complete guide to the 70+ supported CBOR tags
 - **[Creating Custom Tags](doc/custom-tags.md)** - Implement your own tags for domain-specific needs
 - **[API Reference](doc/index.md#api-reference)** - Encoding and decoding API
 - **[Examples](doc/index.md#integration-examples)** - WebAuthn, COSE, IoT, and more
@@ -138,11 +138,13 @@ echo $decimal->normalize(); // "3.14159"
 ```
 
 **Supported Tags:**
-- Date/Time (Tags 0, 1)
-- Big Numbers (Tags 2, 3)
-- Decimal/Binary Fractions (Tags 4, 5)
-- Encoding hints (Tags 21, 22, 23)
-- URIs and MIME (Tags 32, 36)
+- Date/Time (Tags 0, 1) and dates without a time (Tags 100, 1004)
+- Big Numbers (Tags 2, 3), Decimal/Binary Fractions (Tags 4, 5) and Rationals (Tag 30)
+- Encoding hints (Tags 21, 22, 23), embedded CBOR (Tags 24, 63)
+- URIs, MIME and UUIDs (Tags 32, 36, 37, 257)
+- COSE structures and CBOR Web Tokens (Tags 16, 17, 18, 61, 96, 97, 98)
+- Typed and multi-dimensional arrays (Tags 40, 41, 64-87, 1040)
+- IP and network addresses (Tags 52, 54, 260, 261)
 - [And more...](doc/tags.md)
 
 **Create your own:** See [Creating Custom Tags](doc/custom-tags.md) guide.

--- a/doc/custom-tags.md
+++ b/doc/custom-tags.md
@@ -205,12 +205,12 @@ use CBOR\TextStringObject;
 use InvalidArgumentException;
 
 /**
- * Tag 260: Email Address
+ * Tag 64000: Email Address (any number the IANA registry leaves unassigned)
  * Marks a text string as an RFC 5322 email address
  */
 final class EmailTag extends Tag implements Normalizable
 {
-    private const TAG_EMAIL = 260;
+    private const TAG_EMAIL = 64000;
 
     public function __construct(
         int $additionalInformation,
@@ -676,97 +676,15 @@ public function __construct(
 
 ## Integration with Other Specifications
 
-### COSE (RFC 8152) - CBOR Object Signing and Encryption
+### COSE (RFC 9052) and CWT (RFC 8392)
 
-COSE uses several CBOR tags:
+Both are **built in** since 3.4.0: `CoseEncrypt0Tag` (16), `CoseMac0Tag` (17), `CoseSign1Tag` (18),
+`CoseEncryptTag` (96), `CoseMacTag` (97), `CoseSignTag` (98) and `CwtTag` (61) are registered in the decoder by
+default. See [COSE and CWT Tags](tags.md#cose-and-cwt-tags) for what they give access to.
 
-- **Tag 98**: COSE Single Recipient Encrypted
-- **Tag 96**: COSE Encrypted
-- **Tag 97**: COSE MAC'd
-- **Tag 98**: COSE Single Signer
-- **Tag 18**: COSE Sign
-
-Example implementation outline:
-
-```php
-namespace CBOR\Tag\COSE;
-
-use CBOR\CBORObject;
-use CBOR\Tag;
-use CBOR\ListObject;
-
-/**
- * Tag 98: COSE_Sign1 - Single Signer
- * @see https://datatracker.ietf.org/doc/html/rfc8152#section-4.2
- */
-final class COSESign1Tag extends Tag
-{
-    private const TAG_COSE_SIGN1 = 98;
-
-    public function __construct(
-        int $additionalInformation,
-        ?string $data,
-        CBORObject $object
-    ) {
-        if (!$object instanceof ListObject || count($object) !== 4) {
-            throw new InvalidArgumentException(
-                'COSE_Sign1 must be an array of 4 elements'
-            );
-        }
-
-        // Validate structure: [protected, unprotected, payload, signature]
-        // ... validation logic
-
-        parent::__construct($additionalInformation, $data, $object);
-    }
-
-    public static function getTagId(): int
-    {
-        return self::TAG_COSE_SIGN1;
-    }
-
-    // ... implementation
-}
-```
-
-### CWT (RFC 8392) - CBOR Web Token
-
-CWT uses Tag 61 for the entire token:
-
-```php
-namespace CBOR\Tag;
-
-use CBOR\CBORObject;
-use CBOR\Tag;
-use CBOR\Tag\COSE\COSESign1Tag;
-
-/**
- * Tag 61: CBOR Web Token (CWT)
- * @see https://datatracker.ietf.org/doc/html/rfc8392
- */
-final class CWTTag extends Tag
-{
-    private const TAG_CWT = 61;
-
-    public function __construct(
-        int $additionalInformation,
-        ?string $data,
-        CBORObject $object
-    ) {
-        // CWT is typically a COSE_Sign1 or COSE_Mac0
-        if (!$object instanceof COSESign1Tag
-            && !$object instanceof COSEMac0Tag) {
-            throw new InvalidArgumentException(
-                'CWT must wrap a COSE structure'
-            );
-        }
-
-        parent::__construct($additionalInformation, $data, $object);
-    }
-
-    // ... implementation
-}
-```
+They describe the structure only. Verifying a signature or a MAC, and everything about keys and algorithms,
+belongs to a COSE implementation -- [web-auth/cose-lib](https://github.com/web-auth/cose-lib), which also ships
+the algorithm registry of RFC 9053.
 
 ### CoAP (RFC 7252) - Constrained Application Protocol
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -81,6 +81,7 @@ CBORObject (interface)
 │   │   ├── TimestampTag
 │   │   ├── DecimalFractionTag
 │   │   ├── BigFloatTag
+│   │   ├── CoseSign1Tag, UuidTag, SetTag, ... (see tags.md)
 │   │   ├── ... (see Tags Reference)
 │   │   └── GenericTag
 │   └── OtherObject (abstract)
@@ -457,16 +458,21 @@ if ($authenticatorData instanceof MapObject) {
 
 ### COSE (Object Signing)
 
+The six COSE structures of RFC 9052 are built in and registered by default -- see
+[COSE and CWT Tags](tags.md#cose-and-cwt-tags).
+
 ```php
+use CBOR\Tag\CoseSign1Tag;
+
 // Decode a COSE_Sign1 structure
 $coseSign1 = $decoder->decode($stream);
 
-if ($coseSign1 instanceof COSESign1Tag) {
-    $protected = $coseSign1->getProtectedHeaders();
-    $payload = $coseSign1->getPayload();
+if ($coseSign1 instanceof CoseSign1Tag) {
+    $protectedHeader = $coseSign1->getProtectedHeaderAsMap();
+    $payload = $coseSign1->getPayload();     // NullObject when the payload is detached
     $signature = $coseSign1->getSignature();
 
-    // Verify signature
+    // Verifying the signature needs keys and algorithms: use web-auth/cose-lib for that.
 }
 ```
 

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -6,6 +6,17 @@ CBOR tags (Major Type 6) provide semantic information about data values. Tags ar
 
 - [Overview](#overview)
 - [Built-in Tags](#built-in-tags)
+  - [Date/Time Tags](#datetime-tags)
+  - [Big Number Tags](#big-number-tags)
+  - [Fractional Number Tags](#fractional-number-tags)
+  - [Encoded Data Tags](#encoded-data-tags)
+  - [Semantic Tags](#semantic-tags)
+  - [Special CBOR Tags](#special-cbor-tags)
+  - [COSE and CWT Tags](#cose-and-cwt-tags)
+  - [Date Tags](#date-tags)
+  - [Address Tags](#address-tags)
+  - [Typed Array Tags](#typed-array-tags)
+  - [Other Registry Tags](#other-registry-tags)
 - [Using Tags](#using-tags)
 - [Creating Custom Tags](#creating-custom-tags)
 - [IANA Registry](#iana-registry)
@@ -21,7 +32,13 @@ Where:
 - `tag_number` is an integer identifying the semantic meaning
 - `data_item` is any CBOR object that the tag applies to
 
-This library provides implementations for commonly used tags and a generic tag handler for unsupported tags.
+This library implements every tag of the IANA registry listed in the [summary table](#tag-summary-table) below,
+and hands any other tag number to a generic handler that keeps the number and the item without interpreting them.
+
+All of them are registered in the decoder by default. A tag whose content does not match its definition -- a URI
+that is not a text string, a set that is not an array -- is rejected with an `InvalidArgumentException` rather
+than decoded into something it is not. Registering the classes costs nothing until they are used: the decoder
+files them by tag number and only loads the one a document actually mentions.
 
 ## Built-in Tags
 
@@ -451,6 +468,232 @@ $value = $selfDescribed->normalize();
 
 ---
 
+### COSE and CWT Tags
+
+The six COSE structures of [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) and the CBOR Web Token tag
+of [RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392) that wraps them. Each one describes the shape of the
+structure and gives access to its parts; **verifying a signature or a MAC is not done here** and needs a COSE
+implementation such as [web-auth/cose-lib](https://github.com/web-auth/cose-lib).
+
+| Tag | Structure | Class | Content |
+|-----|-----------|-------|---------|
+| 16 | COSE_Encrypt0 | `CoseEncrypt0Tag` | [protected, unprotected, ciphertext] |
+| 17 | COSE_Mac0 | `CoseMac0Tag` | [protected, unprotected, payload, tag] |
+| 18 | COSE_Sign1 | `CoseSign1Tag` | [protected, unprotected, payload, signature] |
+| 96 | COSE_Encrypt | `CoseEncryptTag` | [protected, unprotected, ciphertext, recipients] |
+| 97 | COSE_Mac | `CoseMacTag` | [protected, unprotected, payload, tag, recipients] |
+| 98 | COSE_Sign | `CoseSignTag` | [protected, unprotected, payload, signatures] |
+| 61 | CWT | `CwtTag` | a COSE structure, tagged or not, or a bare claims set |
+
+```php
+use CBOR\Decoder;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+
+$object = Decoder::create()->decode(StringStream::create($encoded));
+
+if ($object instanceof CoseSign1Tag) {
+    // The protected header is signed as it was written, so it travels wrapped in a byte string.
+    $algorithm = $object->getProtectedHeaderAsMap()->normalize()[1] ?? null;
+    $payload = $object->getPayload();     // ByteStringObject, or NullObject when detached
+    $signature = $object->getSignature();
+}
+```
+
+Two shapes that a stricter reading would turn away are accepted on purpose:
+
+- **a detached payload**, which COSE writes as `null`: the content travels out of band and only the signature
+  comes with the structure;
+- **an absent protected header**, which COSE writes as an empty byte string: `getProtectedHeaderAsMap()` answers
+  an empty `MapObject` rather than failing to parse zero bytes.
+
+To build one, `createFromComponents()` takes the parts and serializes the protected header for you:
+
+```php
+$tag = CoseSign1Tag::createFromComponents(
+    $protectedHeader,    // MapObject; encoded into the byte string COSE signs
+    $unprotectedHeader,  // MapObject
+    ByteStringObject::create($payload),
+    ByteStringObject::create($signature)
+);
+```
+
+---
+
+### Date Tags
+
+A calendar day is not an instant: a birthday or an expiry date is the same day everywhere, and pinning it to a
+moment moves it across a day boundary depending on where it is read. [RFC 8943](https://datatracker.ietf.org/doc/html/rfc8943)
+gives it two tags of its own.
+
+| Tag | Description | Class | Accepts |
+|-----|-------------|-------|---------|
+| 100 | Days since 1970-01-01 | `DateTag` | `UnsignedIntegerObject`, `NegativeIntegerObject` |
+| 1004 | RFC 3339 full-date (`YYYY-MM-DD`) | `DateStringTag` | `TextStringObject` |
+
+```php
+use CBOR\Tag\DateTag;
+use CBOR\UnsignedIntegerObject;
+
+$tag = DateTag::create(UnsignedIntegerObject::create(19737));
+echo $tag->normalize()->format('Y-m-d'); // 2024-01-15
+```
+
+PHP has no date-only type, so both normalize to **midnight UTC** -- the reading that keeps the day intact -- and
+neither is affected by the ambient time zone. A day that does not exist (`2013-02-30`) is rejected rather than
+rolled over into the next month.
+
+---
+
+### Address Tags
+
+| Tag | Description | Class | Accepts |
+|-----|-------------|-------|---------|
+| 52 | IPv4 address, prefix or zoned address | `Ipv4Tag` | `ByteStringObject`, or a 2 item `ListObject` |
+| 54 | IPv6 address, prefix or zoned address | `Ipv6Tag` | `ByteStringObject`, or a 2 item `ListObject` |
+| 260 | Network address (IPv4, IPv6 or MAC) | `NetworkAddressTag` | a 4, 6 or 16 byte `ByteStringObject` |
+| 261 | Network address prefix | `NetworkAddressPrefixTag` | a single entry `MapObject` |
+
+Tags 52 and 54 come from [RFC 9164](https://datatracker.ietf.org/doc/html/rfc9164) and carry three shapes under
+one number, told apart by their first item: a byte string is an address, `[length, bytes]` is a prefix whose
+trailing zero bytes may be left out, and `[bytes, zone]` is an address with the zone that scopes it.
+
+```php
+use CBOR\Tag\Ipv6Tag;
+
+echo Ipv6Tag::createFromAddress('2001:db8::1')->normalize(); // 2001:db8::1
+// A prefix normalizes with its length, a zoned address with its zone:
+// "2001:db8::/32", "fe80::1%eth0"
+```
+
+Tags 260 and 261 are the earlier form, which tells the family from the length of the byte string. RFC 9164
+supersedes them; prefer 52 and 54 for anything new.
+
+---
+
+### Typed Array Tags
+
+[RFC 8746](https://datatracker.ietf.org/doc/html/rfc8746) packs an array of numbers of one fixed type into a
+single byte string: a megabyte of samples travels as a megabyte instead of as three. The tag number gives the
+element type, so the only thing the content has to satisfy is being a whole number of elements long.
+
+| Tags | Element | Classes (namespace `CBOR\Tag\TypedArray`) |
+|------|---------|------------------------------------------|
+| 64, 68 | uint8, uint8 clamped | `Uint8ArrayTag`, `Uint8ClampedArrayTag` |
+| 65, 69 | uint16 big / little endian | `Uint16BigEndianArrayTag`, `Uint16LittleEndianArrayTag` |
+| 66, 70 | uint32 big / little endian | `Uint32BigEndianArrayTag`, `Uint32LittleEndianArrayTag` |
+| 67, 71 | uint64 big / little endian | `Uint64BigEndianArrayTag`, `Uint64LittleEndianArrayTag` |
+| 72 | sint8 | `Sint8ArrayTag` |
+| 73, 77 | sint16 big / little endian | `Sint16BigEndianArrayTag`, `Sint16LittleEndianArrayTag` |
+| 74, 78 | sint32 big / little endian | `Sint32BigEndianArrayTag`, `Sint32LittleEndianArrayTag` |
+| 75, 79 | sint64 big / little endian | `Sint64BigEndianArrayTag`, `Sint64LittleEndianArrayTag` |
+| 80, 84 | binary16 big / little endian | `Float16BigEndianArrayTag`, `Float16LittleEndianArrayTag` |
+| 81, 85 | binary32 big / little endian | `Float32BigEndianArrayTag`, `Float32LittleEndianArrayTag` |
+| 82, 86 | binary64 big / little endian | `Float64BigEndianArrayTag`, `Float64LittleEndianArrayTag` |
+| 83, 87 | binary128 big / little endian | `Float128BigEndianArrayTag`, `Float128LittleEndianArrayTag` |
+
+```php
+use CBOR\Tag\TypedArray\Uint16BigEndianArrayTag;
+use CBOR\ByteStringObject;
+
+$tag = Uint16BigEndianArrayTag::create(ByteStringObject::create("\x00\x01\x00\x02"));
+
+count($tag);          // 2
+$tag->normalize();    // [1, 2]
+```
+
+**Returns:** a list of `int` or `float` when normalized. A uint64 above `PHP_INT_MAX` comes back as a decimal
+string rather than as a negative integer.
+
+**The binary128 pair is the exception:** PHP has no quadruple precision float, and returning a binary64 would
+quietly drop fifteen digits, so tags 83 and 87 do not implement `Normalizable`. Use `getChunks()`, which hands
+back the 16 bytes of each element.
+
+#### Tags 40 and 1040: Multi-Dimensional Arrays
+
+The same RFC folds a flat array -- a plain one or a typed array -- into a shape, as `[dimensions, values]`.
+
+| Tag | Order | Class |
+|-----|-------|-------|
+| 40 | Row-major (last index varies fastest) | `RowMajorMultiDimensionalArrayTag` |
+| 1040 | Column-major (first index varies fastest) | `ColumnMajorMultiDimensionalArrayTag` |
+
+```php
+// 40([[2, 3], [1, 2, 3, 4, 5, 6]])
+$tag->getDimensions();  // [2, 3]
+$tag->normalize();      // [[1, 2, 3], [4, 5, 6]]
+// The same values under tag 1040 fold the other way: [[1, 3, 5], [2, 4, 6]]
+```
+
+`normalize()` rejects a document whose dimensions do not account for exactly the number of values it carries.
+
+Tag 41 (`HomogeneousArrayTag`) belongs to the same RFC. It is a hint that every item of an array has the same
+type; the array normalizes as it would untagged, and homogeneity is not checked, since what counts as "the same
+type" is the application's data model rather than CBOR's major types.
+
+---
+
+### Other Registry Tags
+
+| Tag | Description | Class | Accepts |
+|-----|-------------|-------|---------|
+| 25 | String reference | `StringReferenceTag` | `UnsignedIntegerObject` |
+| 26 | Serialised Perl object | `PerlObjectTag` | `ListObject` opening with a text string |
+| 27 | Serialised language-independent object | `LanguageIndependentObjectTag` | `ListObject` opening with a text string |
+| 28 | Shareable value | `ShareableTag` | any object |
+| 29 | Shared value reference | `SharedReferenceTag` | `UnsignedIntegerObject` |
+| 30 | Rational number | `RationalNumberTag` | 2 item `ListObject` [numerator, denominator] |
+| 35 | Regular expression | `RegexpTag` | `TextStringObject` |
+| 37 | Binary UUID | `UuidTag` | a 16 byte `ByteStringObject` |
+| 38 | Language-tagged string | `LanguageTaggedStringTag` | 2 item `ListObject` [language, text] |
+| 39 | Identifier | `IdentifierTag` | any object |
+| 42 | IPLD content identifier (CID) | `IpldContentIdentifierTag` | `ByteStringObject` |
+| 63 | Encoded CBOR sequence | `CBORSequenceTag` | `ByteStringObject` |
+| 256 | String reference namespace | `StringReferenceNamespaceTag` | any object |
+| 257 | Binary MIME message | `BinaryMimeTag` | `ByteStringObject` |
+| 258 | Mathematical finite set | `SetTag` | `ListObject` |
+| 259 | Explicit map | `ExplicitMapTag` | `MapObject` |
+| 1001 | Extended time | `ExtendedTimeTag` | `MapObject` |
+| 1002 | Duration | `DurationTag` | `MapObject` |
+| 1003 | Period | `PeriodTag` | `ListObject` |
+
+A few of them are worth a word.
+
+**Tag 37 (UUID)** normalizes to the canonical `8-4-4-4-12` form and can be built from it:
+
+```php
+use CBOR\Tag\UuidTag;
+
+$tag = UuidTag::createFromUuidString('01234567-89ab-cdef-0123-456789abcdef');
+echo $tag->normalize(); // 01234567-89ab-cdef-0123-456789abcdef
+```
+
+**Tag 30 (rational number)** normalizes to lowest terms, as `"numerator/denominator"` -- or as the numerator
+alone when the denominator reduces to 1. Either part may be a bignum (tags 2 and 3), which is the point of the
+tag: a ratio such as 1/3 has no exact decimal or binary floating point form.
+
+**Tag 63 (CBOR sequence)** is to a sequence what tag 24 is to a single item. `getSequence()` decodes the byte
+string into the items it holds:
+
+```php
+$items = $tag->getSequence(); // CBORObject[]
+```
+
+**Tag 258 (set)** returns its items in the order they were written. Nothing in CBOR keeps a duplicate out of an
+array, so a repeated item is left for the application to notice -- and, most often, to reject the document over,
+since a set that carries one is not what it claims to be.
+
+**Tags 25, 28, 29 and 256 (string references and value sharing)** are recorded rather than resolved. The table a
+reference points into is built while the whole document is read, which is outside the scope of any single tag,
+so the index is returned as it stands and the marked value normalizes as it would untagged.
+
+**Tags 1001, 1002 and 1003 ([RFC 9581](https://datatracker.ietf.org/doc/html/rfc9581))** are returned as the map
+or array they are. The components they allow -- a leap second, a time scale that is not UTC, a resolution below
+the microsecond -- do not all fit `DateTimeImmutable` or `DateInterval`, and flattening them into one would drop
+whichever does not.
+
+---
+
 ## Using Tags
 
 ### Encoding with Tags
@@ -522,31 +765,87 @@ The CBOR Tags registry is maintained by IANA. This library implements the most c
 | 3 | Negative Bignum | `NegativeBigIntegerTag` | RFC 8949 § 3.4.3 |
 | 4 | Decimal Fraction | `DecimalFractionTag` | RFC 8949 § 3.4.4 |
 | 5 | Bigfloat | `BigFloatTag` | RFC 8949 § 3.4.4 |
+| 16 | COSE_Encrypt0 | `CoseEncrypt0Tag` | RFC 9052 |
+| 17 | COSE_Mac0 | `CoseMac0Tag` | RFC 9052 |
+| 18 | COSE_Sign1 | `CoseSign1Tag` | RFC 9052 |
 | 21 | Base64url (expected) | `Base64UrlEncodingTag` | RFC 8949 § 3.4.5.2 |
 | 22 | Base64 (expected) | `Base64EncodingTag` | RFC 8949 § 3.4.5.2 |
 | 23 | Base16 (expected) | `Base16EncodingTag` | RFC 8949 § 3.4.5.2 |
 | 24 | Encoded CBOR | `CBOREncodingTag` | RFC 8949 § 3.4.5.1 |
+| 25 | String reference | `StringReferenceTag` | stringref |
+| 26 | Serialised Perl object | `PerlObjectTag` | IANA registry |
+| 27 | Serialised language-independent object | `LanguageIndependentObjectTag` | IANA registry |
+| 28 | Shareable value | `ShareableTag` | value sharing |
+| 29 | Shared value reference | `SharedReferenceTag` | value sharing |
+| 30 | Rational number | `RationalNumberTag` | IANA registry |
 | 32 | URI | `UriTag` | RFC 8949 § 3.4.5.3 |
 | 33 | Base64url | `Base64UrlTag` | RFC 8949 § 3.4.5.2 |
 | 34 | Base64 | `Base64Tag` | RFC 8949 § 3.4.5.2 |
+| 35 | Regular expression | `RegexpTag` | RFC 7049 |
 | 36 | MIME Message | `MimeTag` | RFC 8949 § 3.4.5.3 |
+| 37 | Binary UUID | `UuidTag` | RFC 4122 |
+| 38 | Language-tagged string | `LanguageTaggedStringTag` | IANA registry |
+| 39 | Identifier | `IdentifierTag` | IANA registry |
+| 40 | Multi-dimensional array, row-major | `RowMajorMultiDimensionalArrayTag` | RFC 8746 |
+| 41 | Homogeneous array | `HomogeneousArrayTag` | RFC 8746 |
+| 42 | IPLD content identifier | `IpldContentIdentifierTag` | IANA registry |
+| 52 | IPv4 address or prefix | `Ipv4Tag` | RFC 9164 |
+| 54 | IPv6 address or prefix | `Ipv6Tag` | RFC 9164 |
+| 61 | CBOR Web Token | `CwtTag` | RFC 8392 |
+| 63 | Encoded CBOR Sequence | `CBORSequenceTag` | RFC 8742 |
+| 64-87 | Typed arrays | `CBOR\Tag\TypedArray\*` | RFC 8746 |
+| 96 | COSE_Encrypt | `CoseEncryptTag` | RFC 9052 |
+| 97 | COSE_Mac | `CoseMacTag` | RFC 9052 |
+| 98 | COSE_Sign | `CoseSignTag` | RFC 9052 |
+| 100 | Date (days since epoch) | `DateTag` | RFC 8943 |
+| 256 | String reference namespace | `StringReferenceNamespaceTag` | stringref |
+| 257 | Binary MIME message | `BinaryMimeTag` | IANA registry |
+| 258 | Mathematical finite set | `SetTag` | IANA registry |
+| 259 | Explicit map | `ExplicitMapTag` | IANA registry |
+| 260 | Network address (legacy) | `NetworkAddressTag` | RFC 9164 App. A |
+| 261 | Network address prefix (legacy) | `NetworkAddressPrefixTag` | RFC 9164 App. A |
+| 1001 | Extended time | `ExtendedTimeTag` | RFC 9581 |
+| 1002 | Duration | `DurationTag` | RFC 9581 |
+| 1003 | Period | `PeriodTag` | RFC 9581 |
+| 1004 | Date string | `DateStringTag` | RFC 8943 |
+| 1040 | Multi-dimensional array, column-major | `ColumnMajorMultiDimensionalArrayTag` | RFC 8746 |
 | 55799 | Self-Describe CBOR | `CBORTag` | RFC 8949 § 3.4.6 |
 
-### Unsupported Tags
+### Tags Not Implemented
 
-For tags not implemented by this library, use `GenericTag`:
+The registry is open ended and most of what is not in the table above is specific to one application. Any tag
+number missing from it decodes to `GenericTag`, which keeps the number and the item without claiming to
+understand either -- nothing is lost, only the semantics are left to the caller.
 
 ```php
 use CBOR\Tag\GenericTag;
-use CBOR\TextStringObject;
 
-// Create a tag with any tag number
-$tag = GenericTag::createFromLoadedData(
-    $additionalInformation,
-    $data,
-    TextStringObject::create('custom data')
+$object = $decoder->decode($stream);
+
+if ($object instanceof GenericTag) {
+    $item = $object->getValue();  // the tagged item, decoded as usual
+}
+```
+
+The tag number is where CBOR puts it: in the additional information for a number up to 23, and in the bytes of
+`getData()` beyond that.
+
+To give one of them a class of its own, see [Creating Custom Tags](custom-tags.md), then register it:
+
+```php
+use CBOR\Decoder;
+use CBOR\OtherObject\OtherObjectManager;
+use CBOR\Tag\TagManager;
+
+$decoder = Decoder::create(
+    TagManager::create()->add(MyTag::class),
+    OtherObjectManager::create()
 );
 ```
+
+Note that a manager built this way replaces the default one rather than adding to it: it holds `MyTag` and
+nothing else. Add back the built-in classes you still need, or register the tag on a manager of your own that
+mirrors the default set.
 
 ---
 

--- a/src/CBORObject.php
+++ b/src/CBORObject.php
@@ -70,6 +70,12 @@ interface CBORObject extends Stringable
 
     public const TAG_BIG_FLOAT = 5;
 
+    public const TAG_COSE_ENCRYPT0 = 16;
+
+    public const TAG_COSE_MAC0 = 17;
+
+    public const TAG_COSE_SIGN1 = 18;
+
     public const TAG_ENCODED_BASE64_URL = 21;
 
     public const TAG_ENCODED_BASE64 = 22;
@@ -78,13 +84,123 @@ interface CBORObject extends Stringable
 
     public const TAG_ENCODED_CBOR = 24;
 
+    public const TAG_STRING_REFERENCE = 25;
+
+    public const TAG_PERL_OBJECT = 26;
+
+    public const TAG_LANGUAGE_INDEPENDENT_OBJECT = 27;
+
+    public const TAG_SHAREABLE = 28;
+
+    public const TAG_SHARED_REFERENCE = 29;
+
+    public const TAG_RATIONAL_NUMBER = 30;
+
     public const TAG_URI = 32;
 
     public const TAG_BASE64_URL = 33;
 
     public const TAG_BASE64 = 34;
 
+    public const TAG_REGULAR_EXPRESSION = 35;
+
     public const TAG_MIME = 36;
+
+    public const TAG_UUID = 37;
+
+    public const TAG_LANGUAGE_TAGGED_STRING = 38;
+
+    public const TAG_IDENTIFIER = 39;
+
+    public const TAG_ROW_MAJOR_MULTI_DIMENSIONAL_ARRAY = 40;
+
+    public const TAG_HOMOGENEOUS_ARRAY = 41;
+
+    public const TAG_IPLD_CONTENT_IDENTIFIER = 42;
+
+    public const TAG_IPV4 = 52;
+
+    public const TAG_IPV6 = 54;
+
+    public const TAG_CWT = 61;
+
+    public const TAG_ENCODED_CBOR_SEQUENCE = 63;
+
+    public const TAG_TYPED_ARRAY_UINT8 = 64;
+
+    public const TAG_TYPED_ARRAY_UINT16_BE = 65;
+
+    public const TAG_TYPED_ARRAY_UINT32_BE = 66;
+
+    public const TAG_TYPED_ARRAY_UINT64_BE = 67;
+
+    public const TAG_TYPED_ARRAY_UINT8_CLAMPED = 68;
+
+    public const TAG_TYPED_ARRAY_UINT16_LE = 69;
+
+    public const TAG_TYPED_ARRAY_UINT32_LE = 70;
+
+    public const TAG_TYPED_ARRAY_UINT64_LE = 71;
+
+    public const TAG_TYPED_ARRAY_SINT8 = 72;
+
+    public const TAG_TYPED_ARRAY_SINT16_BE = 73;
+
+    public const TAG_TYPED_ARRAY_SINT32_BE = 74;
+
+    public const TAG_TYPED_ARRAY_SINT64_BE = 75;
+
+    public const TAG_TYPED_ARRAY_SINT16_LE = 77;
+
+    public const TAG_TYPED_ARRAY_SINT32_LE = 78;
+
+    public const TAG_TYPED_ARRAY_SINT64_LE = 79;
+
+    public const TAG_TYPED_ARRAY_FLOAT16_BE = 80;
+
+    public const TAG_TYPED_ARRAY_FLOAT32_BE = 81;
+
+    public const TAG_TYPED_ARRAY_FLOAT64_BE = 82;
+
+    public const TAG_TYPED_ARRAY_FLOAT128_BE = 83;
+
+    public const TAG_TYPED_ARRAY_FLOAT16_LE = 84;
+
+    public const TAG_TYPED_ARRAY_FLOAT32_LE = 85;
+
+    public const TAG_TYPED_ARRAY_FLOAT64_LE = 86;
+
+    public const TAG_TYPED_ARRAY_FLOAT128_LE = 87;
+
+    public const TAG_COSE_ENCRYPT = 96;
+
+    public const TAG_COSE_MAC = 97;
+
+    public const TAG_COSE_SIGN = 98;
+
+    public const TAG_DATE = 100;
+
+    public const TAG_STRING_REFERENCE_NAMESPACE = 256;
+
+    public const TAG_BINARY_MIME = 257;
+
+    public const TAG_SET = 258;
+
+    public const TAG_EXPLICIT_MAP = 259;
+
+    public const TAG_NETWORK_ADDRESS = 260;
+
+    public const TAG_NETWORK_ADDRESS_PREFIX = 261;
+
+    public const TAG_EXTENDED_TIME = 1001;
+
+    public const TAG_DURATION = 1002;
+
+    public const TAG_PERIOD = 1003;
+
+    public const TAG_DATE_STRING = 1004;
+
+    public const TAG_COLUMN_MAJOR_MULTI_DIMENSIONAL_ARRAY = 1040;
 
     public const TAG_CBOR = 55799;
 

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -21,17 +21,76 @@ use CBOR\Tag\Base64Tag;
 use CBOR\Tag\Base64UrlEncodingTag;
 use CBOR\Tag\Base64UrlTag;
 use CBOR\Tag\BigFloatTag;
+use CBOR\Tag\BinaryMimeTag;
 use CBOR\Tag\CBOREncodingTag;
+use CBOR\Tag\CBORSequenceTag;
 use CBOR\Tag\CBORTag;
+use CBOR\Tag\ColumnMajorMultiDimensionalArrayTag;
+use CBOR\Tag\CoseEncrypt0Tag;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\Tag\CoseMac0Tag;
+use CBOR\Tag\CoseMacTag;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CoseSignTag;
+use CBOR\Tag\CwtTag;
+use CBOR\Tag\DateStringTag;
+use CBOR\Tag\DateTag;
 use CBOR\Tag\DatetimeTag;
 use CBOR\Tag\DecimalFractionTag;
+use CBOR\Tag\DurationTag;
+use CBOR\Tag\ExplicitMapTag;
+use CBOR\Tag\ExtendedTimeTag;
+use CBOR\Tag\HomogeneousArrayTag;
+use CBOR\Tag\IdentifierTag;
+use CBOR\Tag\IpldContentIdentifierTag;
+use CBOR\Tag\Ipv4Tag;
+use CBOR\Tag\Ipv6Tag;
+use CBOR\Tag\LanguageIndependentObjectTag;
+use CBOR\Tag\LanguageTaggedStringTag;
 use CBOR\Tag\MimeTag;
 use CBOR\Tag\NegativeBigIntegerTag;
+use CBOR\Tag\NetworkAddressPrefixTag;
+use CBOR\Tag\NetworkAddressTag;
+use CBOR\Tag\PeriodTag;
+use CBOR\Tag\PerlObjectTag;
+use CBOR\Tag\RationalNumberTag;
+use CBOR\Tag\RegexpTag;
+use CBOR\Tag\RowMajorMultiDimensionalArrayTag;
+use CBOR\Tag\SetTag;
+use CBOR\Tag\ShareableTag;
+use CBOR\Tag\SharedReferenceTag;
+use CBOR\Tag\StringReferenceNamespaceTag;
+use CBOR\Tag\StringReferenceTag;
+use CBOR\Tag\TagInterface;
 use CBOR\Tag\TagManager;
 use CBOR\Tag\TagManagerInterface;
 use CBOR\Tag\TimestampTag;
+use CBOR\Tag\TypedArray\Float128BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Float128LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Float16BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Float16LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Float32BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Float32LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Float64BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Float64LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint16BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint16LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint32BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint32LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint64BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint64LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Sint8ArrayTag;
+use CBOR\Tag\TypedArray\Uint16BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint16LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint32BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint32LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint64BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint64LittleEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint8ArrayTag;
+use CBOR\Tag\TypedArray\Uint8ClampedArrayTag;
 use CBOR\Tag\UnsignedBigIntegerTag;
 use CBOR\Tag\UriTag;
+use CBOR\Tag\UuidTag;
 use InvalidArgumentException;
 use function ord;
 use RuntimeException;
@@ -40,6 +99,91 @@ use const STR_PAD_LEFT;
 
 final class Decoder implements DecoderInterface
 {
+    /**
+     * The tag classes the decoder knows about, by tag number.
+     *
+     * Every entry is a class this library implements from the IANA CBOR tags registry. A tag that is not listed
+     * here -- unassigned, or specific to an application -- is decoded as a GenericTag, which keeps the number and
+     * the item without claiming to understand them.
+     *
+     * @var array<int, class-string<TagInterface>>
+     */
+    private const DEFAULT_TAGS = [
+        CBORObject::TAG_STANDARD_DATETIME => DatetimeTag::class,
+        CBORObject::TAG_EPOCH_DATETIME => TimestampTag::class,
+        CBORObject::TAG_UNSIGNED_BIG_NUM => UnsignedBigIntegerTag::class,
+        CBORObject::TAG_NEGATIVE_BIG_NUM => NegativeBigIntegerTag::class,
+        CBORObject::TAG_DECIMAL_FRACTION => DecimalFractionTag::class,
+        CBORObject::TAG_BIG_FLOAT => BigFloatTag::class,
+        CBORObject::TAG_COSE_ENCRYPT0 => CoseEncrypt0Tag::class,
+        CBORObject::TAG_COSE_MAC0 => CoseMac0Tag::class,
+        CBORObject::TAG_COSE_SIGN1 => CoseSign1Tag::class,
+        CBORObject::TAG_ENCODED_BASE64_URL => Base64UrlEncodingTag::class,
+        CBORObject::TAG_ENCODED_BASE64 => Base64EncodingTag::class,
+        CBORObject::TAG_ENCODED_BASE16 => Base16EncodingTag::class,
+        CBORObject::TAG_ENCODED_CBOR => CBOREncodingTag::class,
+        CBORObject::TAG_STRING_REFERENCE => StringReferenceTag::class,
+        CBORObject::TAG_PERL_OBJECT => PerlObjectTag::class,
+        CBORObject::TAG_LANGUAGE_INDEPENDENT_OBJECT => LanguageIndependentObjectTag::class,
+        CBORObject::TAG_SHAREABLE => ShareableTag::class,
+        CBORObject::TAG_SHARED_REFERENCE => SharedReferenceTag::class,
+        CBORObject::TAG_RATIONAL_NUMBER => RationalNumberTag::class,
+        CBORObject::TAG_URI => UriTag::class,
+        CBORObject::TAG_BASE64_URL => Base64UrlTag::class,
+        CBORObject::TAG_BASE64 => Base64Tag::class,
+        CBORObject::TAG_REGULAR_EXPRESSION => RegexpTag::class,
+        CBORObject::TAG_MIME => MimeTag::class,
+        CBORObject::TAG_UUID => UuidTag::class,
+        CBORObject::TAG_LANGUAGE_TAGGED_STRING => LanguageTaggedStringTag::class,
+        CBORObject::TAG_IDENTIFIER => IdentifierTag::class,
+        CBORObject::TAG_ROW_MAJOR_MULTI_DIMENSIONAL_ARRAY => RowMajorMultiDimensionalArrayTag::class,
+        CBORObject::TAG_HOMOGENEOUS_ARRAY => HomogeneousArrayTag::class,
+        CBORObject::TAG_IPLD_CONTENT_IDENTIFIER => IpldContentIdentifierTag::class,
+        CBORObject::TAG_IPV4 => Ipv4Tag::class,
+        CBORObject::TAG_IPV6 => Ipv6Tag::class,
+        CBORObject::TAG_CWT => CwtTag::class,
+        CBORObject::TAG_ENCODED_CBOR_SEQUENCE => CBORSequenceTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT8 => Uint8ArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT16_BE => Uint16BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT32_BE => Uint32BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT64_BE => Uint64BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT8_CLAMPED => Uint8ClampedArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT16_LE => Uint16LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT32_LE => Uint32LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_UINT64_LE => Uint64LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT8 => Sint8ArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT16_BE => Sint16BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT32_BE => Sint32BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT64_BE => Sint64BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT16_LE => Sint16LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT32_LE => Sint32LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_SINT64_LE => Sint64LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT16_BE => Float16BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT32_BE => Float32BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT64_BE => Float64BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT128_BE => Float128BigEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT16_LE => Float16LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT32_LE => Float32LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT64_LE => Float64LittleEndianArrayTag::class,
+        CBORObject::TAG_TYPED_ARRAY_FLOAT128_LE => Float128LittleEndianArrayTag::class,
+        CBORObject::TAG_COSE_ENCRYPT => CoseEncryptTag::class,
+        CBORObject::TAG_COSE_MAC => CoseMacTag::class,
+        CBORObject::TAG_COSE_SIGN => CoseSignTag::class,
+        CBORObject::TAG_DATE => DateTag::class,
+        CBORObject::TAG_STRING_REFERENCE_NAMESPACE => StringReferenceNamespaceTag::class,
+        CBORObject::TAG_BINARY_MIME => BinaryMimeTag::class,
+        CBORObject::TAG_SET => SetTag::class,
+        CBORObject::TAG_EXPLICIT_MAP => ExplicitMapTag::class,
+        CBORObject::TAG_NETWORK_ADDRESS => NetworkAddressTag::class,
+        CBORObject::TAG_NETWORK_ADDRESS_PREFIX => NetworkAddressPrefixTag::class,
+        CBORObject::TAG_EXTENDED_TIME => ExtendedTimeTag::class,
+        CBORObject::TAG_DURATION => DurationTag::class,
+        CBORObject::TAG_PERIOD => PeriodTag::class,
+        CBORObject::TAG_DATE_STRING => DateStringTag::class,
+        CBORObject::TAG_COLUMN_MAJOR_MULTI_DIMENSIONAL_ARRAY => ColumnMajorMultiDimensionalArrayTag::class,
+        CBORObject::TAG_CBOR => CBORTag::class,
+    ];
+
     /**
      * The maximum nesting depth allowed by default. Deeper structures are rejected as the recursive processing of the
      * data may exhaust the call stack.
@@ -229,28 +373,12 @@ final class Decoder implements DecoderInterface
 
     private function generateTagManager(): TagManagerInterface
     {
-        return TagManager::create([
-            DatetimeTag::class,
-            TimestampTag::class,
+        $manager = TagManager::create();
+        foreach (self::DEFAULT_TAGS as $tagId => $class) {
+            $manager->register($tagId, $class);
+        }
 
-            UnsignedBigIntegerTag::class,
-            NegativeBigIntegerTag::class,
-
-            DecimalFractionTag::class,
-            BigFloatTag::class,
-
-            Base64UrlEncodingTag::class,
-            Base64EncodingTag::class,
-            Base16EncodingTag::class,
-            CBOREncodingTag::class,
-
-            UriTag::class,
-            Base64UrlTag::class,
-            Base64Tag::class,
-            MimeTag::class,
-
-            CBORTag::class,
-        ]);
+        return $manager;
     }
 
     private function generateOtherObjectManager(): OtherObjectManagerInterface

--- a/src/IndefiniteLengthListObject.php
+++ b/src/IndefiniteLengthListObject.php
@@ -25,7 +25,7 @@ class IndefiniteLengthListObject extends AbstractCBORObject implements Countable
     private const ADDITIONAL_INFORMATION = self::LENGTH_INDEFINITE;
 
     /**
-     * @var CBORObject[]
+     * @var array<int, CBORObject>
      */
     private array $data = [];
 
@@ -58,7 +58,7 @@ class IndefiniteLengthListObject extends AbstractCBORObject implements Countable
      * Items that do not implement Normalizable -- the encoding tags or the "break" simple value, for instance -- have
      * no native counterpart and are returned as the CBORObject they are.
      *
-     * @return mixed[]
+     * @return array<int, mixed>
      */
     public function normalize(): array
     {

--- a/src/IndefiniteLengthMapObject.php
+++ b/src/IndefiniteLengthMapObject.php
@@ -111,7 +111,7 @@ class IndefiniteLengthMapObject extends AbstractCBORObject implements Countable,
      * Items that do not implement Normalizable -- the encoding tags or the "break" simple value, for instance -- have
      * no native counterpart and are returned as the CBORObject they are.
      *
-     * @return mixed[]
+     * @return array<int|string, mixed>
      */
     public function normalize(): array
     {

--- a/src/ListObject.php
+++ b/src/ListObject.php
@@ -25,7 +25,7 @@ class ListObject extends AbstractCBORObject implements Countable, IteratorAggreg
     private const MAJOR_TYPE = self::MAJOR_TYPE_LIST;
 
     /**
-     * @var CBORObject[]
+     * @var array<int, CBORObject>
      */
     private array $data;
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -8,6 +8,9 @@ use CBOR\Tag\TagInterface;
 use function chr;
 use InvalidArgumentException;
 
+/**
+ * @phpstan-consistent-constructor
+ */
 abstract class Tag extends AbstractCBORObject implements TagInterface
 {
     private const MAJOR_TYPE = self::MAJOR_TYPE_TAG;

--- a/src/Tag/AbstractCoseTag.php
+++ b/src/Tag/AbstractCoseTag.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\DecoderInterface;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag;
+use function count;
+use InvalidArgumentException;
+use function sprintf;
+
+/**
+ * Common behaviour of the six COSE structures of RFC 9052: tags 16, 17, 18, 96, 97 and 98.
+ *
+ * Every one of them is an array that opens with the same two items -- the protected header, wrapped in a byte
+ * string so that it is signed exactly as it was written, and the unprotected header as a plain map -- and then
+ * differs in what follows. The tag only describes that shape: verifying a signature or a MAC needs keys and
+ * algorithms this library knows nothing about, and belongs to a COSE implementation such as web-auth/cose-lib.
+ *
+ * @see \CBOR\Test\Tag\CoseTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9052
+ */
+abstract class AbstractCoseTag extends Tag implements Normalizable
+{
+    /**
+     * The protected header as it is carried: a byte string whose content is the encoded header map.
+     */
+    public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $item */
+        $item = $this->itemAt(0);
+
+        return $item;
+    }
+
+    /**
+     * The protected header, decoded.
+     *
+     * An empty byte string is the COSE way of saying "no protected header", so it decodes to an empty map rather
+     * than to a parse error.
+     */
+    public function getProtectedHeaderAsMap(
+        ?DecoderInterface $decoder = null
+    ): MapObject|IndefiniteLengthMapObject {
+        $value = $this->getProtectedHeader()
+            ->getValue();
+        if ($value === '') {
+            return MapObject::create();
+        }
+
+        $decoder ??= Decoder::create();
+        $decoded = $decoder->decode(StringStream::create($value));
+        if (! $decoded instanceof MapObject && ! $decoded instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('Protected header is not a valid Map object.');
+        }
+
+        return $decoded;
+    }
+
+    public function getUnprotectedHeader(): MapObject|IndefiniteLengthMapObject
+    {
+        /** @var IndefiniteLengthMapObject|MapObject $item */
+        $item = $this->itemAt(1);
+
+        return $item;
+    }
+
+    /**
+     * @return array<int, mixed> the structure as the array it is
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+
+    /**
+     * Checks the array and the two items every COSE structure opens with.
+     *
+     * @return IndefiniteLengthListObject|ListObject the same object, once it is known to be a list
+     */
+    protected static function assertStructure(
+        CBORObject $object,
+        int $count,
+        string $name
+    ): ListObject|IndefiniteLengthListObject {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException(sprintf('Not a valid %s object. Expected a List object.', $name));
+        }
+        if (count($object) !== $count) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The list shall have %d items.', $name, $count)
+            );
+        }
+
+        $protectedHeader = $object->get(0);
+        if (! $protectedHeader instanceof ByteStringObject && ! $protectedHeader instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The item 1 shall be a Byte String object.', $name)
+            );
+        }
+        $unprotectedHeader = $object->get(1);
+        if (! $unprotectedHeader instanceof MapObject && ! $unprotectedHeader instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The item 2 shall be a Map object.', $name)
+            );
+        }
+
+        return $object;
+    }
+
+    protected static function assertByteStringAt(
+        ListObject|IndefiniteLengthListObject $object,
+        int $index,
+        string $name
+    ): void {
+        $item = $object->get($index);
+        if (! $item instanceof ByteStringObject && ! $item instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The item %d shall be a Byte String object.', $name, $index + 1)
+            );
+        }
+    }
+
+    /**
+     * A payload or a ciphertext may be detached, which COSE spells as null: the content is carried out of band
+     * and only the signature or the tag travels with the structure.
+     */
+    protected static function assertPayloadAt(
+        ListObject|IndefiniteLengthListObject $object,
+        int $index,
+        string $name
+    ): void {
+        $item = $object->get($index);
+        if (! $item instanceof ByteStringObject && ! $item instanceof IndefiniteLengthByteStringObject && ! $item instanceof NullObject) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The item %d shall be a Byte String object or null.', $name, $index + 1)
+            );
+        }
+    }
+
+    protected static function assertListAt(
+        ListObject|IndefiniteLengthListObject $object,
+        int $index,
+        string $name
+    ): void {
+        $item = $object->get($index);
+        if (! $item instanceof ListObject && ! $item instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException(
+                sprintf('Not a valid %s object. The item %d shall be a List object.', $name, $index + 1)
+            );
+        }
+    }
+
+    protected function itemAt(int $index): CBORObject
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->get($index);
+    }
+}

--- a/src/Tag/AbstractIpAddressTag.php
+++ b/src/Tag/AbstractIpAddressTag.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function count;
+use function inet_ntop;
+use InvalidArgumentException;
+use function sprintf;
+use function str_pad;
+use const STR_PAD_RIGHT;
+use function strlen;
+
+/**
+ * Common behaviour of the two IP address tags of RFC 9164: 52 (IPv4) and 54 (IPv6).
+ *
+ * Each tag carries one of three shapes: a byte string, which is a plain address; the array [prefix length,
+ * bytes], which is a prefix whose trailing zero bytes may be left out; or the array [bytes, zone], which is an
+ * address together with the zone identifier that scopes it. The first item tells the last two apart -- an
+ * integer opens a prefix, a byte string an address -- which is why the shapes can share one tag number.
+ */
+abstract class AbstractIpAddressTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $length = static::getAddressLength();
+        if ($object instanceof ByteStringObject || $object instanceof IndefiniteLengthByteStringObject) {
+            if ($object->getLength() !== $length) {
+                throw new InvalidArgumentException(sprintf(
+                    'This tag only accepts a %d byte Byte String object as an address.',
+                    $length
+                ));
+            }
+
+            parent::__construct($additionalInformation, $data, $object);
+
+            return;
+        }
+
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object or a List object.');
+        }
+        if (count($object) !== 2) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains 2 items.');
+        }
+
+        $first = $object->get(0);
+        $second = $object->get(1);
+        if ($first instanceof UnsignedIntegerObject) {
+            if (! $second instanceof ByteStringObject && ! $second instanceof IndefiniteLengthByteStringObject) {
+                throw new InvalidArgumentException('Invalid prefix. Expected a Byte String object.');
+            }
+            if ($second->getLength() > $length) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid prefix. Expected at most %d bytes.',
+                    $length
+                ));
+            }
+            if ((int) $first->normalize() > $length * 8) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid prefix length. Expected at most %d.',
+                    $length * 8
+                ));
+            }
+
+            parent::__construct($additionalInformation, $data, $object);
+
+            return;
+        }
+
+        if (! $first instanceof ByteStringObject && ! $first instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('Invalid address. Expected a Byte String object.');
+        }
+        if ($first->getLength() !== $length) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid address. Expected exactly %d bytes.',
+                $length
+            ));
+        }
+        if (! $second instanceof UnsignedIntegerObject && ! $second instanceof TextStringObject && ! $second instanceof IndefiniteLengthTextStringObject) {
+            throw new InvalidArgumentException('Invalid zone identifier. Expected a Text String or an Unsigned Integer object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    /**
+     * @return string the address in its textual form, followed by "/length" for a prefix or by "%zone" for a
+     *                zoned address
+     */
+    public function normalize(): string
+    {
+        $object = $this->object;
+        if ($object instanceof ByteStringObject || $object instanceof IndefiniteLengthByteStringObject) {
+            return self::toTextualAddress($object->normalize());
+        }
+
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $first = $object->get(0);
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|TextStringObject|UnsignedIntegerObject $second */
+        $second = $object->get(1);
+        if ($first instanceof UnsignedIntegerObject) {
+            // The bytes of a prefix are truncated after the last one that carries a bit of it, so they are
+            // padded back to a full address before being printed.
+            $bytes = str_pad($second->normalize(), static::getAddressLength(), "\0", STR_PAD_RIGHT);
+
+            return self::toTextualAddress($bytes) . '/' . $first->normalize();
+        }
+
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $first */
+        return self::toTextualAddress($first->normalize()) . '%' . $second->normalize();
+    }
+
+    /**
+     * @return int the size of an address of this family, in bytes
+     */
+    abstract protected static function getAddressLength(): int;
+
+    private static function toTextualAddress(string $bytes): string
+    {
+        if (strlen($bytes) !== static::getAddressLength()) {
+            throw new InvalidArgumentException('Invalid address. Cannot be converted into a textual address.');
+        }
+        $address = inet_ntop($bytes);
+        if ($address === false) {
+            throw new InvalidArgumentException('Invalid address. Cannot be converted into a textual address.');
+        }
+
+        return $address;
+    }
+}

--- a/src/Tag/AbstractMultiDimensionalArrayTag.php
+++ b/src/Tag/AbstractMultiDimensionalArrayTag.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use function array_values;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\UnsignedIntegerObject;
+use function count;
+use InvalidArgumentException;
+use function is_array;
+
+/**
+ * Common behaviour of the two multi-dimensional array tags of RFC 8746: 40 (row-major) and 1040 (column-major).
+ *
+ * The content is the two element array [dimensions, values], where the values are a flat array -- a plain CBOR
+ * array or one of the typed array tags -- and the dimensions say how to fold it. Only the order in which the
+ * flat positions are walked separates the two tags, which is what getStrides() describes.
+ */
+abstract class AbstractMultiDimensionalArrayTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        if (count($object) !== 2) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains 2 items.');
+        }
+
+        $dimensions = $object->get(0);
+        if (! $dimensions instanceof ListObject && ! $dimensions instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('Invalid dimensions. Expected a List object.');
+        }
+        if (count($dimensions) === 0) {
+            throw new InvalidArgumentException('Invalid dimensions. Expected at least one dimension.');
+        }
+        foreach ($dimensions as $dimension) {
+            if (! $dimension instanceof UnsignedIntegerObject) {
+                throw new InvalidArgumentException('Invalid dimensions. Expected Unsigned Integer objects.');
+            }
+        }
+
+        $values = $object->get(1);
+        // A typed array tag is the other half of RFC 8746 and the reason the values are not always a plain array.
+        if (! $values instanceof ListObject && ! $values instanceof IndefiniteLengthListObject && ! ($values instanceof TagInterface && $values instanceof Normalizable)) {
+            throw new InvalidArgumentException('Invalid values. Expected a List object or a typed array tag.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    /**
+     * @return array<int, int> the size of each dimension, outermost first
+     */
+    public function getDimensions(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+        /** @var IndefiniteLengthListObject|ListObject $dimensions */
+        $dimensions = $object->get(0);
+
+        $result = [];
+        foreach ($dimensions as $dimension) {
+            /** @var UnsignedIntegerObject $dimension */
+            $value = $dimension->normalize();
+            $asInteger = (int) $value;
+            // A CBOR unsigned integer goes up to 2^64-1; such a dimension could not be built anyway, and
+            // silently wrapping it would produce a shape that has nothing to do with the document.
+            if ((string) $asInteger !== $value) {
+                throw new InvalidArgumentException('Invalid dimensions. The value is too large.');
+            }
+            $result[] = $asInteger;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<int, mixed> the values as they are laid out in the document, before folding
+     */
+    public function getFlatValues(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+        /** @var CBORObject&Normalizable $values */
+        $values = $object->get(1);
+        $normalized = $values->normalize();
+        if (! is_array($normalized)) {
+            throw new InvalidArgumentException('Invalid values. Expected a List object or a typed array tag.');
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @return array<int, mixed> the values folded into as many nested arrays as there are dimensions
+     */
+    public function normalize(): array
+    {
+        $dimensions = $this->getDimensions();
+        $values = $this->getFlatValues();
+
+        $expected = 1;
+        foreach ($dimensions as $dimension) {
+            $expected *= $dimension;
+            if ($expected > count($values)) {
+                throw new InvalidArgumentException('Invalid data. The dimensions do not match the number of values.');
+            }
+        }
+        if ($expected !== count($values)) {
+            throw new InvalidArgumentException('Invalid data. The dimensions do not match the number of values.');
+        }
+
+        return self::fold($values, $dimensions, static::getStrides($dimensions), 0, 0);
+    }
+
+    /**
+     * The distance between two consecutive positions along each dimension.
+     *
+     * @param array<int, int> $dimensions
+     *
+     * @return array<int, int>
+     */
+    abstract protected static function getStrides(array $dimensions): array;
+
+    /**
+     * @param array<int, mixed> $values
+     * @param array<int, int>   $dimensions
+     * @param array<int, int>   $strides
+     *
+     * @return array<int, mixed>
+     */
+    private static function fold(array $values, array $dimensions, array $strides, int $level, int $offset): array
+    {
+        $isLast = $level === count($dimensions) - 1;
+        $result = [];
+        for ($index = 0; $index < $dimensions[$level]; ++$index) {
+            $position = $offset + $index * $strides[$level];
+            $result[] = $isLast ? $values[$position] : self::fold($values, $dimensions, $strides, $level + 1, $position);
+        }
+
+        return $result;
+    }
+}

--- a/src/Tag/BinaryMimeTag.php
+++ b/src/Tag/BinaryMimeTag.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 257: a MIME message, headers included, carried as a byte string.
+ *
+ * It is the counterpart of tag 36 for a message that is not valid UTF-8 -- a transfer encoding of binary, say --
+ * which a text string could not hold.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class BinaryMimeTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_BINARY_MIME;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_BINARY_MIME);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function normalize(): string
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/CBORSequenceTag.php
+++ b/src/Tag/CBORSequenceTag.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\DecoderInterface;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\StringStream;
+use CBOR\Tag;
+use InvalidArgumentException;
+use function strlen;
+use function substr;
+
+/**
+ * Tag 63: a byte string holding an encoded CBOR sequence (RFC 8742), i.e. zero or more data items one after the
+ * other, with no enclosing array.
+ *
+ * It is to a sequence what tag 24 is to a single data item. The bytes are not decoded on the way in -- the tag
+ * only says what they are -- so getSequence() is where a caller opts into parsing them.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class CBORSequenceTag extends Tag
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_ENCODED_CBOR_SEQUENCE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_ENCODED_CBOR_SEQUENCE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Decodes the sequence the byte string holds.
+     *
+     * A CBOR sequence carries no framing, so the only way to find where an item ends is to decode it. The stream
+     * abstraction of this library cannot report how far it was consumed, so each item is re-encoded and the bytes
+     * it accounts for are dropped from the front. Every object of this library reproduces the head it was decoded
+     * from, which makes the round trip exact; a mismatch would mean the item was rewritten on the way out, so it
+     * is reported rather than silently used to advance past the wrong number of bytes.
+     *
+     * @return CBORObject[] the items, in the order they appear; an empty byte string is an empty sequence
+     */
+    public function getSequence(?DecoderInterface $decoder = null): array
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+        $remaining = $object->getValue();
+        $decoder ??= Decoder::create();
+
+        $items = [];
+        while ($remaining !== '') {
+            $item = $decoder->decode(StringStream::create($remaining));
+            $encoded = (string) $item;
+            $length = strlen($encoded);
+            if ($length === 0 || substr($remaining, 0, $length) !== $encoded) {
+                throw new InvalidArgumentException('Invalid data. The sequence cannot be decoded.');
+            }
+            $items[] = $item;
+            $remaining = substr($remaining, $length);
+        }
+
+        return $items;
+    }
+}

--- a/src/Tag/ColumnMajorMultiDimensionalArrayTag.php
+++ b/src/Tag/ColumnMajorMultiDimensionalArrayTag.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Tag;
+use function count;
+
+/**
+ * Tag 1040: a multi-dimensional array in column-major order, i.e. the first index varies fastest -- the layout
+ * Fortran, MATLAB and most numerical libraries use.
+ *
+ * @see \CBOR\Test\Tag\TypedArrayTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8746#section-3.2
+ */
+final class ColumnMajorMultiDimensionalArrayTag extends AbstractMultiDimensionalArrayTag
+{
+    public static function getTagId(): int
+    {
+        return self::TAG_COLUMN_MAJOR_MULTI_DIMENSIONAL_ARRAY;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COLUMN_MAJOR_MULTI_DIMENSIONAL_ARRAY);
+
+        return new self($ai, $data, $object);
+    }
+
+    protected static function getStrides(array $dimensions): array
+    {
+        $strides = [];
+        $stride = 1;
+        for ($index = 0, $length = count($dimensions); $index < $length; ++$index) {
+            $strides[$index] = $stride;
+            $stride *= $dimensions[$index];
+        }
+
+        return $strides;
+    }
+}

--- a/src/Tag/CoseEncrypt0Tag.php
+++ b/src/Tag/CoseEncrypt0Tag.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 16: COSE_Encrypt0, a single recipient encrypted message -- the recipient is known out of band, so the
+ * structure carries no recipient list.
+ *
+ * Content: [protected header, unprotected header, ciphertext].
+ */
+final class CoseEncrypt0Tag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseEncrypt0';
+
+    private const ITEM_COUNT = 3;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_ENCRYPT0;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_ENCRYPT0);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(MapObject $protectedHeader, MapObject $unprotectedHeader, ByteStringObject|NullObject $ciphertext): self
+    {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $ciphertext,
+        ]));
+    }
+
+    /**
+     * The ciphertext, or null when it is detached and carried out of band.
+     */
+    public function getCiphertext(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+}

--- a/src/Tag/CoseEncryptTag.php
+++ b/src/Tag/CoseEncryptTag.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 96: COSE_Encrypt, an encrypted message with one or more recipients, each of which carries the content
+ * encryption key in its own way.
+ *
+ * Content: [protected header, unprotected header, ciphertext, recipients].
+ */
+final class CoseEncryptTag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseEncrypt';
+
+    private const ITEM_COUNT = 4;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+        self::assertListAt($structure, 3, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_ENCRYPT;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_ENCRYPT);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(
+        MapObject $protectedHeader,
+        MapObject $unprotectedHeader,
+        ByteStringObject|NullObject $ciphertext,
+        ListObject $recipients
+    ): self {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $ciphertext,
+            $recipients,
+        ]));
+    }
+
+    /**
+     * The ciphertext, or null when it is detached and carried out of band.
+     */
+    public function getCiphertext(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+
+    public function getRecipients(): ListObject|IndefiniteLengthListObject
+    {
+        /** @var IndefiniteLengthListObject|ListObject $item */
+        $item = $this->itemAt(3);
+
+        return $item;
+    }
+}

--- a/src/Tag/CoseMac0Tag.php
+++ b/src/Tag/CoseMac0Tag.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 17: COSE_Mac0, a MAC'd message with a single recipient -- the key is known out of band, so the structure
+ * carries no recipient list.
+ *
+ * Content: [protected header, unprotected header, payload, tag].
+ */
+final class CoseMac0Tag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseMac0';
+
+    private const ITEM_COUNT = 4;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+        self::assertByteStringAt($structure, 3, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_MAC0;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_MAC0);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(
+        MapObject $protectedHeader,
+        MapObject $unprotectedHeader,
+        ByteStringObject|NullObject $payload,
+        ByteStringObject $tag
+    ): self {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $payload,
+            $tag,
+        ]));
+    }
+
+    /**
+     * The payload, or null when it is detached and carried out of band.
+     */
+    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+
+    public function getTag(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $item */
+        $item = $this->itemAt(3);
+
+        return $item;
+    }
+}

--- a/src/Tag/CoseMacTag.php
+++ b/src/Tag/CoseMacTag.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 97: COSE_Mac, a MAC'd message with one or more recipients, each of which carries the MAC key in its own
+ * way.
+ *
+ * Content: [protected header, unprotected header, payload, tag, recipients].
+ */
+final class CoseMacTag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseMac';
+
+    private const ITEM_COUNT = 5;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+        self::assertByteStringAt($structure, 3, self::STRUCTURE_NAME);
+        self::assertListAt($structure, 4, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_MAC;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_MAC);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(
+        MapObject $protectedHeader,
+        MapObject $unprotectedHeader,
+        ByteStringObject|NullObject $payload,
+        ByteStringObject $tag,
+        ListObject $recipients
+    ): self {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $payload,
+            $tag,
+            $recipients,
+        ]));
+    }
+
+    /**
+     * The payload, or null when it is detached and carried out of band.
+     */
+    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+
+    public function getTag(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $item */
+        $item = $this->itemAt(3);
+
+        return $item;
+    }
+
+    public function getRecipients(): ListObject|IndefiniteLengthListObject
+    {
+        /** @var IndefiniteLengthListObject|ListObject $item */
+        $item = $this->itemAt(4);
+
+        return $item;
+    }
+}

--- a/src/Tag/CoseSign1Tag.php
+++ b/src/Tag/CoseSign1Tag.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 18: COSE_Sign1, a message signed by a single signer.
+ *
+ * Content: [protected header, unprotected header, payload, signature]. This is the structure WebAuthn and CWT
+ * use most.
+ */
+final class CoseSign1Tag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseSign1';
+
+    private const ITEM_COUNT = 4;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+        self::assertByteStringAt($structure, 3, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_SIGN1;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_SIGN1);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(
+        MapObject $protectedHeader,
+        MapObject $unprotectedHeader,
+        ByteStringObject|NullObject $payload,
+        ByteStringObject $signature
+    ): self {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $payload,
+            $signature,
+        ]));
+    }
+
+    /**
+     * The payload, or null when it is detached and carried out of band.
+     */
+    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+
+    public function getSignature(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $item */
+        $item = $this->itemAt(3);
+
+        return $item;
+    }
+}

--- a/src/Tag/CoseSignTag.php
+++ b/src/Tag/CoseSignTag.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag;
+
+/**
+ * Tag 98: COSE_Sign, a message signed by one or more signers, each with its own headers and signature.
+ *
+ * Content: [protected header, unprotected header, payload, signatures].
+ */
+final class CoseSignTag extends AbstractCoseTag
+{
+    private const STRUCTURE_NAME = 'CoseSign';
+
+    private const ITEM_COUNT = 4;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        $structure = self::assertStructure($object, self::ITEM_COUNT, self::STRUCTURE_NAME);
+        self::assertPayloadAt($structure, 2, self::STRUCTURE_NAME);
+        self::assertListAt($structure, 3, self::STRUCTURE_NAME);
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_COSE_SIGN;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_COSE_SIGN);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the structure from its parts, serializing the protected header into the byte string COSE signs.
+     */
+    public static function createFromComponents(
+        MapObject $protectedHeader,
+        MapObject $unprotectedHeader,
+        ByteStringObject|NullObject $payload,
+        ListObject $signatures
+    ): self {
+        return self::create(ListObject::create([
+            ByteStringObject::create((string) $protectedHeader),
+            $unprotectedHeader,
+            $payload,
+            $signatures,
+        ]));
+    }
+
+    /**
+     * The payload, or null when it is detached and carried out of band.
+     */
+    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject|NullObject
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|NullObject $item */
+        $item = $this->itemAt(2);
+
+        return $item;
+    }
+
+    public function getSignatures(): ListObject|IndefiniteLengthListObject
+    {
+        /** @var IndefiniteLengthListObject|ListObject $item */
+        $item = $this->itemAt(3);
+
+        return $item;
+    }
+}

--- a/src/Tag/CwtTag.php
+++ b/src/Tag/CwtTag.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 61: a CBOR Web Token (RFC 8392).
+ *
+ * The tag says "what follows is a CWT" and nothing more; the token itself is a COSE structure -- tagged, as
+ * CoseSign1Tag and its siblings, or untagged, in which case it is the bare array COSE defines -- or, for an
+ * unsecured token, the claims set as a plain map. All three are accepted; none is verified here, since
+ * validating a signature needs keys this library knows nothing about.
+ *
+ * @see \CBOR\Test\Tag\CoseTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8392#section-6
+ */
+final class CwtTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof MapObject && ! $object instanceof IndefiniteLengthMapObject && ! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject && ! $object instanceof TagInterface) {
+            throw new InvalidArgumentException('This tag only accepts a Map object, a List object or a COSE tag.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_CWT;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_CWT);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function normalize(): mixed
+    {
+        $object = $this->object;
+
+        return $object instanceof Normalizable ? $object->normalize() : $object;
+    }
+}

--- a/src/Tag/DateStringTag.php
+++ b/src/Tag/DateStringTag.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use InvalidArgumentException;
+
+/**
+ * Tag 1004: a date in the RFC 3339 "full-date" form, i.e. YYYY-MM-DD, with no time and no time zone.
+ *
+ * It is the text counterpart of tag 100. As there, PHP has no date-only type, so normalize() returns midnight
+ * UTC. A day that does not exist -- 2013-02-30, say -- is rejected rather than rolled over into the next month.
+ *
+ * @see \CBOR\Test\Tag\DateTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8943
+ */
+final class DateStringTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof TextStringObject && ! $object instanceof IndefiniteLengthTextStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Text String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_DATE_STRING;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_DATE_STRING);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return DateTimeInterface midnight UTC on the day the tag denotes
+     */
+    public function normalize(): DateTimeInterface
+    {
+        /** @var IndefiniteLengthTextStringObject|TextStringObject $object */
+        $object = $this->object;
+
+        // The leading "!" resets every field the format does not carry, so the time is midnight rather than the
+        // current one -- otherwise the same document would normalize to a different instant every second.
+        $result = DateTimeImmutable::createFromFormat('!Y-m-d', $object->normalize(), new DateTimeZone('UTC'));
+        $errors = DateTimeImmutable::getLastErrors();
+        // As of PHP 8.2 a parse with nothing to report returns false instead of an array of empty counters.
+        $exact = $errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0);
+        if ($result === false || ! $exact) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+        }
+
+        return $result;
+    }
+}

--- a/src/Tag/DateTag.php
+++ b/src/Tag/DateTag.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
+use CBOR\CBORObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\UnsignedIntegerObject;
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+/**
+ * Tag 100: a date, as the number of days since 1970-01-01, with no time and no time zone.
+ *
+ * It is what tag 1 is to an instant: a birthday or an expiry date is a calendar day everywhere at once, and
+ * pinning it to a moment -- which is what tag 0 or tag 1 would do -- moves it across a day boundary depending on
+ * where it is read. PHP has no date-only type, so normalize() returns midnight UTC, the reading that keeps the
+ * day intact as long as the time zone is left alone.
+ *
+ * @see \CBOR\Test\Tag\DateTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8943
+ */
+final class DateTag extends Tag implements Normalizable
+{
+    private const SECONDS_PER_DAY = 86400;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof UnsignedIntegerObject && ! $object instanceof NegativeIntegerObject) {
+            throw new InvalidArgumentException('This tag only accepts an Integer object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_DATE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_DATE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return DateTimeInterface midnight UTC on the day the tag denotes
+     */
+    public function normalize(): DateTimeInterface
+    {
+        /** @var NegativeIntegerObject|UnsignedIntegerObject $object */
+        $object = $this->object;
+
+        try {
+            $seconds = BigInteger::of($object->normalize())
+                ->multipliedBy(self::SECONDS_PER_DAY)
+                ->toInt();
+        } catch (MathException $throwable) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object', 0, $throwable);
+        }
+
+        $result = DateTimeImmutable::createFromFormat('U', (string) $seconds);
+        if ($result === false) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a datetime object');
+        }
+
+        return $result;
+    }
+}

--- a/src/Tag/DurationTag.php
+++ b/src/Tag/DurationTag.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 1002: a duration, i.e. an amount of time with no anchor on the timeline.
+ *
+ * As with tag 1001, RFC 9581 encodes it as a map of components, and the components it allows do not all fit a
+ * PHP DateInterval, so the map is returned as it stands.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9581#section-4
+ */
+final class DurationTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof MapObject && ! $object instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('This tag only accepts a Map object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_DURATION;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_DURATION);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthMapObject|MapObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/ExplicitMapTag.php
+++ b/src/Tag/ExplicitMapTag.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 259: a map meant as a key-value dictionary, as opposed to an object with named fields.
+ *
+ * The distinction matters when CBOR is converted to a format where the two are not spelled the same way. The
+ * value is a plain map here, and normalize() returns it as one.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class ExplicitMapTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof MapObject && ! $object instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('This tag only accepts a Map object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_EXPLICIT_MAP;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_EXPLICIT_MAP);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthMapObject|MapObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/ExtendedTimeTag.php
+++ b/src/Tag/ExtendedTimeTag.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 1001: an extended time, i.e. an instant with more than the seconds tag 1 can carry -- a clock quality, a
+ * time scale, a UTC offset, a leap second indicator.
+ *
+ * RFC 9581 builds the value out of a map whose keys select what is present, and the combinations do not all map
+ * onto a PHP date object: a leap second, a time scale that is not UTC or a resolution below the microsecond all
+ * describe instants DateTimeImmutable cannot hold. The map is therefore returned as it stands rather than
+ * flattened into a date that would silently lose one of them.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9581#section-3
+ */
+final class ExtendedTimeTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof MapObject && ! $object instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('This tag only accepts a Map object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_EXTENDED_TIME;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_EXTENDED_TIME);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthMapObject|MapObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/HomogeneousArrayTag.php
+++ b/src/Tag/HomogeneousArrayTag.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 41: an array whose items are all of the same type.
+ *
+ * The tag is a hint for the consumer -- it lets a statically typed decoder allocate one kind of slot -- and adds
+ * nothing to the value, so the array normalizes exactly as it would untagged. Homogeneity is not checked: what
+ * counts as "the same type" is the application's data model, not CBOR's major types.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8746#section-3
+ */
+final class HomogeneousArrayTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_HOMOGENEOUS_ARRAY;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_HOMOGENEOUS_ARRAY);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/IdentifierTag.php
+++ b/src/Tag/IdentifierTag.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+
+/**
+ * Tag 39: marks the item it wraps as an identifier -- a name to be compared, not a value to be interpreted.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class IdentifierTag extends Tag implements Normalizable
+{
+    public static function getTagId(): int
+    {
+        return self::TAG_IDENTIFIER;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_IDENTIFIER);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * The tag says something about the item it wraps rather than about its value, so the item is normalized on
+     * its own. Use getValue() when the tag itself matters.
+     */
+    public function normalize(): mixed
+    {
+        $object = $this->object;
+
+        return $object instanceof Normalizable ? $object->normalize() : $object;
+    }
+}

--- a/src/Tag/IpldContentIdentifierTag.php
+++ b/src/Tag/IpldContentIdentifierTag.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 42: an IPLD content identifier (CID), as used by IPFS and other content addressed systems.
+ *
+ * The byte string is a multibase prefixed CID: the leading 0x00 identity byte followed by the binary CID itself.
+ * Neither the prefix nor the multihash inside it is interpreted here -- decoding them belongs to a CID library --
+ * so the value is returned as the raw bytes it holds.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class IpldContentIdentifierTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_IPLD_CONTENT_IDENTIFIER;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_IPLD_CONTENT_IDENTIFIER);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function normalize(): string
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/Ipv4Tag.php
+++ b/src/Tag/Ipv4Tag.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Tag;
+use function inet_pton;
+use InvalidArgumentException;
+use function strlen;
+
+/**
+ * Tag 52: an IPv4 address, prefix or zoned address (RFC 9164).
+ *
+ * @see \CBOR\Test\Tag\IpAddressTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9164
+ */
+final class Ipv4Tag extends AbstractIpAddressTag
+{
+    private const ADDRESS_LENGTH = 4;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_IPV4;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_IPV4);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the tag from the dotted quad form.
+     */
+    public static function createFromAddress(string $address): self
+    {
+        $bytes = inet_pton($address);
+        if ($bytes === false || strlen($bytes) !== self::ADDRESS_LENGTH) {
+            throw new InvalidArgumentException('Invalid data. The value is not a valid IPv4 address.');
+        }
+
+        return self::create(ByteStringObject::create($bytes));
+    }
+
+    protected static function getAddressLength(): int
+    {
+        return self::ADDRESS_LENGTH;
+    }
+}

--- a/src/Tag/Ipv6Tag.php
+++ b/src/Tag/Ipv6Tag.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Tag;
+use function inet_pton;
+use InvalidArgumentException;
+use function strlen;
+
+/**
+ * Tag 54: an IPv6 address, prefix or zoned address (RFC 9164).
+ *
+ * @see \CBOR\Test\Tag\IpAddressTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9164
+ */
+final class Ipv6Tag extends AbstractIpAddressTag
+{
+    private const ADDRESS_LENGTH = 16;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_IPV6;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_IPV6);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the tag from the colon separated form.
+     */
+    public static function createFromAddress(string $address): self
+    {
+        $bytes = inet_pton($address);
+        if ($bytes === false || strlen($bytes) !== self::ADDRESS_LENGTH) {
+            throw new InvalidArgumentException('Invalid data. The value is not a valid IPv6 address.');
+        }
+
+        return self::create(ByteStringObject::create($bytes));
+    }
+
+    protected static function getAddressLength(): int
+    {
+        return self::ADDRESS_LENGTH;
+    }
+}

--- a/src/Tag/LanguageIndependentObjectTag.php
+++ b/src/Tag/LanguageIndependentObjectTag.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use function count;
+use InvalidArgumentException;
+
+/**
+ * Tag 27: a serialised language-independent object, encoded as an array whose first item is the type name and
+ * whose remaining items are the arguments its constructor was called with.
+ *
+ * Nothing is instantiated here, and nothing should be: rebuilding an object graph from an untrusted document is
+ * how deserialization vulnerabilities happen. The array is returned as data.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class LanguageIndependentObjectTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        if (count($object) < 1) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains at least 1 item.');
+        }
+        $name = $object->get(0);
+        if (! $name instanceof TextStringObject && ! $name instanceof IndefiniteLengthTextStringObject) {
+            throw new InvalidArgumentException('Invalid type name. Expected a Text String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_LANGUAGE_INDEPENDENT_OBJECT;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_LANGUAGE_INDEPENDENT_OBJECT);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function getTypeName(): string
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+        /** @var IndefiniteLengthTextStringObject|TextStringObject $name */
+        $name = $object->get(0);
+
+        return $name->normalize();
+    }
+
+    /**
+     * @return array<int, mixed> the type name followed by the constructor arguments
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/LanguageTaggedStringTag.php
+++ b/src/Tag/LanguageTaggedStringTag.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use function count;
+use InvalidArgumentException;
+
+/**
+ * Tag 38: a string together with the language it is written in, as the two element array [language, text].
+ *
+ * The language is a BCP 47 tag such as "fr-CA". It is carried as written rather than parsed: matching and
+ * fallback are the application's business.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class LanguageTaggedStringTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        if (count($object) !== 2) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains 2 items.');
+        }
+        foreach ([$object->get(0), $object->get(1)] as $item) {
+            if (! $item instanceof TextStringObject && ! $item instanceof IndefiniteLengthTextStringObject) {
+                throw new InvalidArgumentException('This tag only accepts Text String objects.');
+            }
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_LANGUAGE_TAGGED_STRING;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_LANGUAGE_TAGGED_STRING);
+
+        return new self($ai, $data, $object);
+    }
+
+    public static function createFromLanguageAndText(string $language, string $text): self
+    {
+        return self::create(ListObject::create([
+            TextStringObject::create($language),
+            TextStringObject::create($text),
+        ]));
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->textAt(0);
+    }
+
+    public function getText(): string
+    {
+        return $this->textAt(1);
+    }
+
+    /**
+     * @return array{0: string, 1: string} the language tag and the text, in the order they are encoded
+     */
+    public function normalize(): array
+    {
+        return [$this->getLanguage(), $this->getText()];
+    }
+
+    private function textAt(int $index): string
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+        /** @var IndefiniteLengthTextStringObject|TextStringObject $item */
+        $item = $object->get($index);
+
+        return $item->normalize();
+    }
+}

--- a/src/Tag/NetworkAddressPrefixTag.php
+++ b/src/Tag/NetworkAddressPrefixTag.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use function count;
+use InvalidArgumentException;
+
+/**
+ * Tag 261: a network address prefix, given as the single entry map {address bytes: prefix length}.
+ *
+ * As with tag 260, RFC 9164 supersedes it with the prefix form of tags 52 and 54. It is kept for the documents
+ * that predate the RFC.
+ *
+ * @see \CBOR\Test\Tag\IpAddressTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9164#appendix-A
+ */
+final class NetworkAddressPrefixTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof MapObject && ! $object instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('This tag only accepts a Map object.');
+        }
+        if (count($object) !== 1) {
+            throw new InvalidArgumentException('This tag only accepts a Map object that contains 1 item.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_NETWORK_ADDRESS_PREFIX;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_NETWORK_ADDRESS_PREFIX);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * The key of the single entry is the address, in the same raw byte form NetworkAddressTag carries, so it is
+     * returned as it stands rather than printed: a binary map key has no textual form to fall back on.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthMapObject|MapObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/NetworkAddressTag.php
+++ b/src/Tag/NetworkAddressTag.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use function bin2hex;
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use function implode;
+use function in_array;
+use function inet_ntop;
+use InvalidArgumentException;
+use function str_split;
+use function strlen;
+
+/**
+ * Tag 260: a network address, given as its bytes -- 4 for IPv4, 16 for IPv6, 6 for a MAC address.
+ *
+ * This is the earlier, length-discriminated form. RFC 9164 replaced it with tags 52 and 54, which name the
+ * family in the tag number instead, and this one is kept because documents that predate the RFC still use it.
+ * Prefer Ipv4Tag and Ipv6Tag for anything new.
+ *
+ * @see \CBOR\Test\Tag\IpAddressTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9164#appendix-A
+ */
+final class NetworkAddressTag extends Tag implements Normalizable
+{
+    private const MAC_LENGTH = 6;
+
+    private const IPV4_LENGTH = 4;
+
+    private const IPV6_LENGTH = 16;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+        if (! in_array($object->getLength(), [self::IPV4_LENGTH, self::MAC_LENGTH, self::IPV6_LENGTH], true)) {
+            throw new InvalidArgumentException('This tag only accepts a 4, 6 or 16 byte Byte String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_NETWORK_ADDRESS;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_NETWORK_ADDRESS);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return string a dotted quad, a colon separated IPv6 address, or a colon separated MAC address
+     */
+    public function normalize(): string
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+        $value = $object->normalize();
+
+        if (strlen($value) === self::MAC_LENGTH) {
+            return implode(':', str_split(bin2hex($value), 2));
+        }
+
+        $address = inet_ntop($value);
+        if ($address === false) {
+            throw new InvalidArgumentException('Invalid address. Cannot be converted into a textual address.');
+        }
+
+        return $address;
+    }
+}

--- a/src/Tag/PeriodTag.php
+++ b/src/Tag/PeriodTag.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 1003: a period, i.e. a stretch of the timeline delimited by two of the time values RFC 9581 defines.
+ *
+ * The array holds a start and an end, a start and a duration, or one of the two and a null standing for an open
+ * end. Which of those it is depends on the items themselves, and the items may be extended times (tag 1001) that
+ * this library deliberately leaves unflattened, so the array is returned as it stands.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://datatracker.ietf.org/doc/html/rfc9581#section-5
+ */
+final class PeriodTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_PERIOD;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_PERIOD);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/PerlObjectTag.php
+++ b/src/Tag/PerlObjectTag.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use function count;
+use InvalidArgumentException;
+
+/**
+ * Tag 26: a serialised Perl object, encoded as an array whose first item is the class name and whose remaining
+ * items are the arguments its constructor was called with.
+ *
+ * Nothing is instantiated here, and nothing should be: rebuilding an object graph from an untrusted document is
+ * how deserialization vulnerabilities happen. The array is returned as data.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class PerlObjectTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        if (count($object) < 1) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains at least 1 item.');
+        }
+        $name = $object->get(0);
+        if (! $name instanceof TextStringObject && ! $name instanceof IndefiniteLengthTextStringObject) {
+            throw new InvalidArgumentException('Invalid class name. Expected a Text String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_PERL_OBJECT;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_PERL_OBJECT);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function getClassName(): string
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+        /** @var IndefiniteLengthTextStringObject|TextStringObject $name */
+        $name = $object->get(0);
+
+        return $name->normalize();
+    }
+
+    /**
+     * @return array<int, mixed> the class name followed by the constructor arguments
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/RationalNumberTag.php
+++ b/src/Tag/RationalNumberTag.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use Brick\Math\BigInteger;
+use Brick\Math\Exception\MathException;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\UnsignedIntegerObject;
+use function count;
+use InvalidArgumentException;
+
+/**
+ * Tag 30: a rational number, encoded as the two element array [numerator, denominator].
+ *
+ * Either part may itself be a bignum (tags 2 and 3), which is the point of the tag: a ratio such as 1/3 has no
+ * exact binary or decimal floating point form, so it is carried as the pair it is.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://peteroupc.github.io/CBOR/rational.html
+ */
+final class RationalNumberTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        if (count($object) !== 2) {
+            throw new InvalidArgumentException('This tag only accepts a List object that contains 2 items.');
+        }
+
+        $numerator = $object->get(0);
+        $denominator = $object->get(1);
+        if (! $numerator instanceof UnsignedIntegerObject && ! $numerator instanceof NegativeIntegerObject && ! $numerator instanceof UnsignedBigIntegerTag && ! $numerator instanceof NegativeBigIntegerTag) {
+            throw new InvalidArgumentException('Invalid numerator. Expected an integer or a big integer object.');
+        }
+        // The denominator is unsigned: RFC-registered rationals carry the sign on the numerator only.
+        if (! $denominator instanceof UnsignedIntegerObject && ! $denominator instanceof UnsignedBigIntegerTag) {
+            throw new InvalidArgumentException(
+                'Invalid denominator. Expected an unsigned integer or an unsigned big integer object.'
+            );
+        }
+        if ($denominator instanceof UnsignedIntegerObject && $denominator->normalize() === '0') {
+            throw new InvalidArgumentException('Invalid denominator. The value shall not be zero.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_RATIONAL_NUMBER;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_RATIONAL_NUMBER);
+
+        return new self($ai, $data, $object);
+    }
+
+    public static function createFromNumeratorAndDenominator(CBORObject $numerator, CBORObject $denominator): self
+    {
+        return self::create(ListObject::create([$numerator, $denominator]));
+    }
+
+    /**
+     * @return string the value in lowest terms, as "numerator/denominator" -- or as the numerator alone when the
+     *                denominator reduces to 1
+     */
+    public function normalize(): string
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        try {
+            $numerator = BigInteger::of(self::valueOf($object->get(0)));
+            $denominator = BigInteger::of(self::valueOf($object->get(1)));
+            // A zero denominator carried by a bignum only shows up here: reading it means decoding the byte
+            // string, which is too much work to do while the tag is merely being built.
+            if ((string) $denominator === '0') {
+                throw new InvalidArgumentException('Invalid denominator. The value shall not be zero.');
+            }
+
+            // The reduction is done by hand rather than with BigRational, whose API moved between the versions
+            // of brick/math this library supports.
+            $divisor = $numerator->gcd($denominator);
+            $numerator = $numerator->dividedBy($divisor);
+            $denominator = $denominator->dividedBy($divisor);
+        } catch (MathException $throwable) {
+            throw new InvalidArgumentException('Invalid data. Cannot be converted into a rational number', 0, $throwable);
+        }
+
+        return (string) $denominator === '1' ? (string) $numerator : $numerator . '/' . $denominator;
+    }
+
+    /**
+     * @return string the decimal representation of an integer that may well not fit a PHP one
+     */
+    private static function valueOf(CBORObject $object): string
+    {
+        /** @var NegativeBigIntegerTag|NegativeIntegerObject|UnsignedBigIntegerTag|UnsignedIntegerObject $object */
+        return $object->normalize();
+    }
+}

--- a/src/Tag/RegexpTag.php
+++ b/src/Tag/RegexpTag.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use InvalidArgumentException;
+
+/**
+ * Tag 35: a regular expression.
+ *
+ * RFC 7049 defined the tag and RFC 8949 dropped it, but the IANA registry keeps it and documents still carry it.
+ * The dialect -- PCRE, ECMA-262, POSIX -- is not part of the tag, so the pattern is carried as written and never
+ * compiled here: handing an untrusted pattern to preg_match() is a decision for the application, not the decoder.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class RegexpTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof TextStringObject && ! $object instanceof IndefiniteLengthTextStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Text String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_REGULAR_EXPRESSION;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_REGULAR_EXPRESSION);
+
+        return new self($ai, $data, $object);
+    }
+
+    public function normalize(): string
+    {
+        /** @var IndefiniteLengthTextStringObject|TextStringObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/RowMajorMultiDimensionalArrayTag.php
+++ b/src/Tag/RowMajorMultiDimensionalArrayTag.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Tag;
+use function count;
+
+/**
+ * Tag 40: a multi-dimensional array in row-major order, i.e. the last index varies fastest -- the layout C and
+ * PHP nested arrays use.
+ *
+ * @see \CBOR\Test\Tag\TypedArrayTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8746#section-3.1
+ */
+final class RowMajorMultiDimensionalArrayTag extends AbstractMultiDimensionalArrayTag
+{
+    public static function getTagId(): int
+    {
+        return self::TAG_ROW_MAJOR_MULTI_DIMENSIONAL_ARRAY;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_ROW_MAJOR_MULTI_DIMENSIONAL_ARRAY);
+
+        return new self($ai, $data, $object);
+    }
+
+    protected static function getStrides(array $dimensions): array
+    {
+        $strides = [];
+        $stride = 1;
+        for ($index = count($dimensions) - 1; $index >= 0; --$index) {
+            $strides[$index] = $stride;
+            $stride *= $dimensions[$index];
+        }
+
+        return $strides;
+    }
+}

--- a/src/Tag/SetTag.php
+++ b/src/Tag/SetTag.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use InvalidArgumentException;
+
+/**
+ * Tag 258: a mathematical finite set, encoded as an array.
+ *
+ * The array is the encoding of a set, not a set in itself: nothing in CBOR keeps a duplicate out of it. The
+ * items are therefore returned in the order they were written, and it is up to the application to decide what a
+ * repeated item means -- rejecting the document, most often, since a set that carries one is not what it claims.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class SetTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ListObject && ! $object instanceof IndefiniteLengthListObject) {
+            throw new InvalidArgumentException('This tag only accepts a List object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_SET;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_SET);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function normalize(): array
+    {
+        /** @var IndefiniteLengthListObject|ListObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/ShareableTag.php
+++ b/src/Tag/ShareableTag.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+
+/**
+ * Tag 28: marks the item it wraps as shareable, so that later occurrences may refer back to it with tag 29.
+ *
+ * Sharing is what lets a document hold a cyclic or repeated structure without repeating its encoding. Resolving
+ * a reference needs the table of the values marked so far, which is per document rather than per item, so this
+ * library records the mark and leaves the resolution to the application.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://cbor.schmorp.de/value-sharing
+ */
+final class ShareableTag extends Tag implements Normalizable
+{
+    public static function getTagId(): int
+    {
+        return self::TAG_SHAREABLE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_SHAREABLE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * The tag says something about the item it wraps rather than about its value, so the item is normalized on
+     * its own. Use getValue() when the tag itself matters.
+     */
+    public function normalize(): mixed
+    {
+        $object = $this->object;
+
+        return $object instanceof Normalizable ? $object->normalize() : $object;
+    }
+}

--- a/src/Tag/SharedReferenceTag.php
+++ b/src/Tag/SharedReferenceTag.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\UnsignedIntegerObject;
+use InvalidArgumentException;
+
+/**
+ * Tag 29: a reference to a value marked shareable by tag 28, given as its index.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://cbor.schmorp.de/value-sharing
+ */
+final class SharedReferenceTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof UnsignedIntegerObject) {
+            throw new InvalidArgumentException('This tag only accepts an Unsigned Integer object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_SHARED_REFERENCE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_SHARED_REFERENCE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return string the index, as a decimal string: a CBOR unsigned integer may exceed PHP_INT_MAX
+     */
+    public function normalize(): string
+    {
+        /** @var UnsignedIntegerObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/StringReferenceNamespaceTag.php
+++ b/src/Tag/StringReferenceNamespaceTag.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+
+/**
+ * Tag 256: opens a namespace for the string references (tag 25) that appear inside the item it wraps.
+ *
+ * The strings a reference may point at are the ones seen since the namespace was opened, which makes the table
+ * a property of the enclosing document rather than of any single item. This library records the namespace and
+ * leaves the resolution to the application.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://cbor.schmorp.de/stringref
+ */
+final class StringReferenceNamespaceTag extends Tag implements Normalizable
+{
+    public static function getTagId(): int
+    {
+        return self::TAG_STRING_REFERENCE_NAMESPACE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_STRING_REFERENCE_NAMESPACE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * The tag says something about the item it wraps rather than about its value, so the item is normalized on
+     * its own. Use getValue() when the tag itself matters.
+     */
+    public function normalize(): mixed
+    {
+        $object = $this->object;
+
+        return $object instanceof Normalizable ? $object->normalize() : $object;
+    }
+}

--- a/src/Tag/StringReferenceTag.php
+++ b/src/Tag/StringReferenceTag.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use CBOR\CBORObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use CBOR\UnsignedIntegerObject;
+use InvalidArgumentException;
+
+/**
+ * Tag 25: a reference to a string already seen in the enclosing tag 256 namespace, given as its index.
+ *
+ * The index is returned as it stands: the table it points into is built while the document is read, which is
+ * outside the scope of a single tag.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ * @see https://cbor.schmorp.de/stringref
+ */
+final class StringReferenceTag extends Tag implements Normalizable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof UnsignedIntegerObject) {
+            throw new InvalidArgumentException('This tag only accepts an Unsigned Integer object.');
+        }
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_STRING_REFERENCE;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_STRING_REFERENCE);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * @return string the index, as a decimal string: a CBOR unsigned integer may exceed PHP_INT_MAX
+     */
+    public function normalize(): string
+    {
+        /** @var UnsignedIntegerObject $object */
+        $object = $this->object;
+
+        return $object->normalize();
+    }
+}

--- a/src/Tag/TagManager.php
+++ b/src/Tag/TagManager.php
@@ -48,6 +48,29 @@ final class TagManager implements TagManagerInterface
     }
 
     /**
+     * Registers a class under a tag number given up front, rather than asked of the class itself.
+     *
+     * add() has to load the class to call getTagId() on it. A manager that carries the whole IANA registry the
+     * library implements would therefore load every one of those classes before a single byte is decoded, when
+     * a document mentions two or three of them at most. Here the class is only named, and the autoloader is
+     * left alone until the tag actually turns up in a document.
+     *
+     * The tag number is taken at face value: nothing checks that the class agrees with it, since checking is
+     * exactly what would load the class.
+     *
+     * @param class-string<TagInterface> $class
+     */
+    public function register(int $tagId, string $class): self
+    {
+        if ($tagId < 0) {
+            throw new InvalidArgumentException('Invalid tag ID.');
+        }
+        $this->classes[$tagId] = $class;
+
+        return $this;
+    }
+
+    /**
      * @return class-string<TagInterface>
      */
     public function getClassForValue(int $value): string

--- a/src/Tag/TypedArray/AbstractNumericTypedArrayTag.php
+++ b/src/Tag/TypedArray/AbstractNumericTypedArrayTag.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+use function array_map;
+use CBOR\Normalizable;
+use CBOR\OtherObject\HalfPrecisionFloatObject;
+use InvalidArgumentException;
+use function is_float;
+use function is_int;
+use function sprintf;
+use function unpack;
+
+/**
+ * A typed array whose elements PHP can represent, i.e. every one of RFC 8746 but the binary128 pair.
+ */
+abstract class AbstractNumericTypedArrayTag extends AbstractTypedArrayTag implements Normalizable
+{
+    /**
+     * @return array<int, float|int|string> the elements, in the order they are stored
+     */
+    public function normalize(): array
+    {
+        return array_map(
+            static fn (string $chunk) => static::decodeElement($chunk),
+            $this->getChunks()
+        );
+    }
+
+    abstract protected static function decodeElement(string $chunk): float|int|string;
+
+    /**
+     * @return int|string the value, as a decimal string when it is too large for a PHP integer -- which happens
+     *                    for the upper half of a uint64, and for a uint32 on a 32 bit build
+     */
+    protected static function unsignedInteger(string $format, string $chunk): int|string
+    {
+        $value = (int) self::unpackOne($format, $chunk);
+        // The bits are right, only their reading as a signed integer is not: %u prints them as the unsigned
+        // number they stand for, at whatever width this build of PHP uses.
+        return $value < 0 ? sprintf('%u', $value) : $value;
+    }
+
+    /**
+     * Reads an element that unpack() already returns as the signed integer it stands for.
+     */
+    protected static function integer(string $format, string $chunk): int
+    {
+        return (int) self::unpackOne($format, $chunk);
+    }
+
+    /**
+     * Reads an element that unpack() can only return unsigned, and that means a two's complement signed number
+     * of $bits bits. Only widths narrower than a PHP integer go through here: at 64 bits the shifts below would
+     * overflow, and unpack() needs no help anyway.
+     */
+    protected static function signedInteger(string $format, string $chunk, int $bits): int
+    {
+        $value = (int) self::unpackOne($format, $chunk);
+        $limit = 1 << ($bits - 1);
+
+        return $value >= $limit ? $value - (1 << $bits) : $value;
+    }
+
+    protected static function float(string $format, string $chunk): float
+    {
+        return (float) self::unpackOne($format, $chunk);
+    }
+
+    /**
+     * PHP has no binary16 type and no unpack() format for it, so the conversion of the simple value that carries
+     * one is reused: the two bytes are the same in both places.
+     */
+    protected static function halfPrecisionFloat(string $chunk): float
+    {
+        return HalfPrecisionFloatObject::create($chunk)
+            ->normalize();
+    }
+
+    private static function unpackOne(string $format, string $chunk): float|int
+    {
+        $unpacked = unpack($format, $chunk);
+        $value = $unpacked === false ? null : ($unpacked[1] ?? null);
+        if (! is_int($value) && ! is_float($value)) {
+            throw new InvalidArgumentException('Invalid data. The element cannot be decoded.');
+        }
+
+        return $value;
+    }
+}

--- a/src/Tag/TypedArray/AbstractTypedArrayTag.php
+++ b/src/Tag/TypedArray/AbstractTypedArrayTag.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\Tag;
+use function count;
+use Countable;
+use InvalidArgumentException;
+use function sprintf;
+use function str_split;
+
+/**
+ * Common behaviour of the typed array tags of RFC 8746, i.e. tags 64 to 87.
+ *
+ * A typed array is a byte string read as a sequence of numbers of one fixed width and one fixed byte order. It
+ * is what an array of tag 2 bignums or of doubles would be, minus the head each of those items would carry: a
+ * megabyte of samples travels as a megabyte, not as three.
+ *
+ * The tag number alone gives the element type, so the byte string only has to be a whole number of elements
+ * long. That is the one thing checked here; the elements themselves are decoded on demand.
+ *
+ * @see \CBOR\Test\Tag\TypedArrayTagTest
+ * @see https://datatracker.ietf.org/doc/html/rfc8746
+ *
+ * @phpstan-consistent-constructor
+ */
+abstract class AbstractTypedArrayTag extends Tag implements Countable
+{
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+        $size = static::getElementSize();
+        if ($object->getLength() % $size !== 0) {
+            throw new InvalidArgumentException(
+                sprintf('This tag only accepts a Byte String object whose length is a multiple of %d.', $size)
+            );
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    /**
+     * @return int<1, max> the width of one element, in bytes
+     */
+    abstract public static function getElementSize(): int;
+
+    public function count(): int
+    {
+        return count($this->getChunks());
+    }
+
+    /**
+     * @return array<int, string> the raw bytes of each element, in the order they are stored
+     */
+    public function getChunks(): array
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+        $value = $object->getValue();
+        if ($value === '') {
+            // str_split() answers [''] rather than [] for an empty string before PHP 8.2.
+            return [];
+        }
+
+        return str_split($value, static::getElementSize());
+    }
+}

--- a/src/Tag/TypedArray/Float128BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float128BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 83: an array of IEEE 754 binary128 values, big endian.
+ *
+ * PHP has no quadruple precision float and no way to build one out of the bytes without losing what makes it
+ * one, so this tag carries the elements rather than converting them: getChunks() hands back the 16 bytes of
+ * each, for a caller that knows what to do with them. That is also why it is not Normalizable -- returning a
+ * binary64 here would quietly drop 15 digits of precision.
+ */
+final class Float128BigEndianArrayTag extends AbstractTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT128_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 16;
+    }
+}

--- a/src/Tag/TypedArray/Float128LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float128LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 87: an array of IEEE 754 binary128 values, little endian.
+ *
+ * PHP has no quadruple precision float and no way to build one out of the bytes without losing what makes it
+ * one, so this tag carries the elements rather than converting them: getChunks() hands back the 16 bytes of
+ * each, for a caller that knows what to do with them. That is also why it is not Normalizable -- returning a
+ * binary64 here would quietly drop 15 digits of precision.
+ */
+final class Float128LittleEndianArrayTag extends AbstractTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT128_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 16;
+    }
+}

--- a/src/Tag/TypedArray/Float16BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float16BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 80: an array of IEEE 754 binary16 values, big endian.
+ */
+final class Float16BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT16_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::halfPrecisionFloat($chunk);
+    }
+}

--- a/src/Tag/TypedArray/Float16LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float16LittleEndianArrayTag.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+use function strrev;
+
+/**
+ * Tag 84: an array of IEEE 754 binary16 values, little endian.
+ */
+final class Float16LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT16_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::halfPrecisionFloat(strrev($chunk));
+    }
+}

--- a/src/Tag/TypedArray/Float32BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float32BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 81: an array of IEEE 754 binary32 values, big endian.
+ */
+final class Float32BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT32_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::float('G', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Float32LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float32LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 85: an array of IEEE 754 binary32 values, little endian.
+ */
+final class Float32LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT32_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::float('g', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Float64BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float64BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 82: an array of IEEE 754 binary64 values, big endian.
+ */
+final class Float64BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT64_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::float('E', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Float64LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Float64LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 86: an array of IEEE 754 binary64 values, little endian.
+ */
+final class Float64LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_FLOAT64_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    protected static function decodeElement(string $chunk): float
+    {
+        return self::float('e', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Sint16BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint16BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 73: an array of signed 16 bit integers, big endian.
+ */
+final class Sint16BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT16_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::signedInteger('n', $chunk, 16);
+    }
+}

--- a/src/Tag/TypedArray/Sint16LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint16LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 77: an array of signed 16 bit integers, little endian.
+ */
+final class Sint16LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT16_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::signedInteger('v', $chunk, 16);
+    }
+}

--- a/src/Tag/TypedArray/Sint32BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint32BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 74: an array of signed 32 bit integers, big endian.
+ */
+final class Sint32BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT32_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::signedInteger('N', $chunk, 32);
+    }
+}

--- a/src/Tag/TypedArray/Sint32LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint32LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 78: an array of signed 32 bit integers, little endian.
+ */
+final class Sint32LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT32_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::signedInteger('V', $chunk, 32);
+    }
+}

--- a/src/Tag/TypedArray/Sint64BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint64BigEndianArrayTag.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 75: an array of signed 64 bit integers, big endian.
+ */
+final class Sint64BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT64_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    /**
+     * A 64 bit two's complement element is exactly what unpack() answers on a 64 bit build: the range of the
+     * element is the range of a PHP integer, so nothing has to be corrected.
+     */
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::integer('J', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Sint64LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Sint64LittleEndianArrayTag.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 79: an array of signed 64 bit integers, little endian.
+ */
+final class Sint64LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT64_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    /**
+     * A 64 bit two's complement element is exactly what unpack() answers on a 64 bit build: the range of the
+     * element is the range of a PHP integer, so nothing has to be corrected.
+     */
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::integer('P', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Sint8ArrayTag.php
+++ b/src/Tag/TypedArray/Sint8ArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 72: an array of signed 8 bit integers.
+ */
+final class Sint8ArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_SINT8;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 1;
+    }
+
+    protected static function decodeElement(string $chunk): int
+    {
+        return self::integer('c', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/TypedArrayFactoryTrait.php
+++ b/src/Tag/TypedArray/TypedArrayFactoryTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+use CBOR\CBORObject;
+use CBOR\Tag;
+
+/**
+ * The two factories every typed array tag shares.
+ *
+ * They live in a trait rather than in AbstractTypedArrayTag because they need "new static": in the abstract
+ * class nothing rules out a subclass that takes different constructor arguments, whereas the final classes that
+ * use the trait are the end of the line.
+ */
+trait TypedArrayFactoryTrait
+{
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new static($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): static
+    {
+        [$ai, $data] = self::determineComponents(static::getTagId());
+
+        return new static($ai, $data, $object);
+    }
+}

--- a/src/Tag/TypedArray/Uint16BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint16BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 65: an array of unsigned 16 bit integers, big endian.
+ */
+final class Uint16BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT16_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('n', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint16LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint16LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 69: an array of unsigned 16 bit integers, little endian.
+ */
+final class Uint16LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT16_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 2;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('v', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint32BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint32BigEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 66: an array of unsigned 32 bit integers, big endian.
+ */
+final class Uint32BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT32_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('N', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint32LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint32LittleEndianArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 70: an array of unsigned 32 bit integers, little endian.
+ */
+final class Uint32LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT32_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 4;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('V', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint64BigEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint64BigEndianArrayTag.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 67: an array of unsigned 64 bit integers, big endian.
+ *
+ * Half of that range is beyond PHP_INT_MAX, so an element above it comes back as a decimal string.
+ */
+final class Uint64BigEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT64_BE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('J', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint64LittleEndianArrayTag.php
+++ b/src/Tag/TypedArray/Uint64LittleEndianArrayTag.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 71: an array of unsigned 64 bit integers, little endian.
+ *
+ * Half of that range is beyond PHP_INT_MAX, so an element above it comes back as a decimal string.
+ */
+final class Uint64LittleEndianArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT64_LE;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 8;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('P', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint8ArrayTag.php
+++ b/src/Tag/TypedArray/Uint8ArrayTag.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 64: an array of unsigned 8 bit integers.
+ */
+final class Uint8ArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT8;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 1;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('C', $chunk);
+    }
+}

--- a/src/Tag/TypedArray/Uint8ClampedArrayTag.php
+++ b/src/Tag/TypedArray/Uint8ClampedArrayTag.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag\TypedArray;
+
+/**
+ * Tag 68: an array of unsigned 8 bit integers with clamped arithmetic, i.e. the JavaScript Uint8ClampedArray.
+ *
+ * Clamping describes how a producer turns a wider value into a byte -- 300 becomes 255 rather than 44 -- so it
+ * shapes what was written, not how it is read. The elements decode exactly as tag 64.
+ */
+final class Uint8ClampedArrayTag extends AbstractNumericTypedArrayTag
+{
+    use TypedArrayFactoryTrait;
+
+    public static function getTagId(): int
+    {
+        return self::TAG_TYPED_ARRAY_UINT8_CLAMPED;
+    }
+
+    public static function getElementSize(): int
+    {
+        return 1;
+    }
+
+    protected static function decodeElement(string $chunk): int|string
+    {
+        return self::unsignedInteger('C', $chunk);
+    }
+}

--- a/src/Tag/UuidTag.php
+++ b/src/Tag/UuidTag.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Tag;
+
+use function bin2hex;
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\Normalizable;
+use CBOR\Tag;
+use function hex2bin;
+use InvalidArgumentException;
+use function preg_match;
+use function str_replace;
+use function str_split;
+use function strlen;
+use function strtolower;
+use function vsprintf;
+
+/**
+ * Tag 37: a binary UUID as defined by RFC 4122, in the 16 byte big endian form.
+ *
+ * The length is enforced: a UUID that is not 16 bytes is not a UUID, and normalize() would otherwise return a
+ * string that merely looks like one.
+ *
+ * @see \CBOR\Test\Tag\RegistryTagsTest
+ */
+final class UuidTag extends Tag implements Normalizable
+{
+    private const LENGTH = 16;
+
+    public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
+    {
+        if (! $object instanceof ByteStringObject && ! $object instanceof IndefiniteLengthByteStringObject) {
+            throw new InvalidArgumentException('This tag only accepts a Byte String object.');
+        }
+        if ($object->getLength() !== self::LENGTH) {
+            throw new InvalidArgumentException('This tag only accepts a 16 byte Byte String object.');
+        }
+
+        parent::__construct($additionalInformation, $data, $object);
+    }
+
+    public static function getTagId(): int
+    {
+        return self::TAG_UUID;
+    }
+
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
+    {
+        return new self($additionalInformation, $data, $object);
+    }
+
+    public static function create(CBORObject $object): self
+    {
+        [$ai, $data] = self::determineComponents(self::TAG_UUID);
+
+        return new self($ai, $data, $object);
+    }
+
+    /**
+     * Builds the tag from the 8-4-4-4-12 textual form, with or without the dashes.
+     */
+    public static function createFromUuidString(string $uuid): self
+    {
+        $hexadecimal = str_replace('-', '', strtolower($uuid));
+        if (preg_match('/^[0-9a-f]{32}$/', $hexadecimal) !== 1) {
+            throw new InvalidArgumentException('Invalid data. The value is not a valid UUID.');
+        }
+
+        return self::create(ByteStringObject::create((string) hex2bin($hexadecimal)));
+    }
+
+    /**
+     * @return non-empty-string the canonical 8-4-4-4-12 lowercase form
+     */
+    public function normalize(): string
+    {
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $object */
+        $object = $this->object;
+        $value = $object->normalize();
+        if (strlen($value) !== self::LENGTH) {
+            throw new InvalidArgumentException('Invalid data. The value is not a valid UUID.');
+        }
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($value), 4));
+    }
+}

--- a/tests/Tag/CoseTagTest.php
+++ b/tests/Tag/CoseTagTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseEncrypt0Tag;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\Tag\CoseMac0Tag;
+use CBOR\Tag\CoseMacTag;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CoseSignTag;
+use CBOR\Tag\CwtTag;
+use CBOR\Tag\TagInterface;
+use CBOR\Test\CBORTestCase;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The six COSE structures of RFC 9052 and the CWT tag of RFC 8392 that wraps them.
+ *
+ * @internal
+ */
+final class CoseTagTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, class-string<TagInterface>}>
+     */
+    public static function taggedDocuments(): iterable
+    {
+        yield 'tag 16 (COSE_Encrypt0)' => ['d08340a043616263', CoseEncrypt0Tag::class];
+        yield 'tag 17 (COSE_Mac0)' => ['d18440a04361626343746167', CoseMac0Tag::class];
+        yield 'tag 18 (COSE_Sign1)' => ['d28443a10126a043666f6f43736967', CoseSign1Tag::class];
+        yield 'tag 96 (COSE_Encrypt)' => ['d8608440a04361626380', CoseEncryptTag::class];
+        yield 'tag 97 (COSE_Mac)' => ['d8618540a0436162634374616780', CoseMacTag::class];
+        yield 'tag 98 (COSE_Sign)' => ['d8628440a04361626380', CoseSignTag::class];
+        yield 'tag 61 (CWT)' => ['d83dd28443a10126a043666f6f43736967', CwtTag::class];
+    }
+
+    /**
+     * @param class-string<TagInterface> $class
+     */
+    #[DataProvider('taggedDocuments')]
+    #[Test]
+    public function theDecoderCreatesTheTagClassRegisteredForTheTagNumber(string $data, string $class): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($data)));
+
+        static::assertInstanceOf($class, $object);
+    }
+
+    #[Test]
+    public function aSingleSignerStructureExposesEachOfItsParts(): void
+    {
+        // 18([h'a10126', {}, h'666f6f', h'736967'])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d28443a10126a043666f6f43736967')));
+
+        static::assertInstanceOf(CoseSign1Tag::class, $object);
+        static::assertSame('a10126', bin2hex($object->getProtectedHeader()->getValue()));
+        static::assertSame([
+            1 => '-7',
+        ], $object->getProtectedHeaderAsMap()
+            ->normalize());
+        static::assertCount(0, $object->getUnprotectedHeader());
+        static::assertInstanceOf(ByteStringObject::class, $object->getPayload());
+        static::assertSame('foo', $object->getPayload()->getValue());
+        static::assertSame('sig', $object->getSignature()->getValue());
+    }
+
+    /**
+     * A payload may be carried out of band, which COSE spells as null. Rejecting it would turn a detached
+     * signature -- the reason the structure exists -- into a decoding error.
+     */
+    #[Test]
+    public function aDetachedPayloadIsAccepted(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d28443a10126a0f643736967')));
+
+        static::assertInstanceOf(CoseSign1Tag::class, $object);
+        static::assertInstanceOf(NullObject::class, $object->getPayload());
+    }
+
+    /**
+     * COSE writes "no protected header" as an empty byte string, which is not the encoding of an empty map.
+     */
+    #[Test]
+    public function anAbsentProtectedHeaderIsReadAsAnEmptyMap(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d28440a043666f6f43736967')));
+
+        static::assertInstanceOf(CoseSign1Tag::class, $object);
+        static::assertCount(0, $object->getProtectedHeaderAsMap());
+    }
+
+    #[Test]
+    public function aStructureWithTheWrongNumberOfItemsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not a valid CoseSign1 object. The list shall have 4 items.');
+        CoseSign1Tag::create(ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create(),
+            ByteStringObject::create('foo'),
+        ]));
+    }
+
+    #[Test]
+    public function aStructureWhoseSignatureIsNotAByteStringIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not a valid CoseSign1 object. The item 4 shall be a Byte String object.');
+        CoseSign1Tag::create(ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create(),
+            ByteStringObject::create('foo'),
+            TextStringObject::create('sig'),
+        ]));
+    }
+
+    #[Test]
+    public function aStructureThatIsNotAnArrayIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Not a valid CoseMac0 object. Expected a List object.');
+        CoseMac0Tag::create(MapObject::create());
+    }
+
+    #[Test]
+    public function aStructureBuiltFromItsPartsDecodesBackIntoItself(): void
+    {
+        $protectedHeader = MapObject::create()
+            ->add(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7));
+        $tag = CoseSign1Tag::createFromComponents(
+            $protectedHeader,
+            MapObject::create(),
+            ByteStringObject::create('foo'),
+            ByteStringObject::create('sig')
+        );
+
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) $tag));
+
+        static::assertInstanceOf(CoseSign1Tag::class, $object);
+        static::assertSame([
+            1 => '-7',
+        ], $object->getProtectedHeaderAsMap()
+            ->normalize());
+        static::assertSame('foo', $object->getPayload()->getValue());
+    }
+
+    #[Test]
+    public function aMultipleRecipientStructureExposesItsRecipients(): void
+    {
+        // 96([h'', {}, h'abc', [ ]])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d8608440a04361626380')));
+
+        static::assertInstanceOf(CoseEncryptTag::class, $object);
+        static::assertSame('abc', $object->getCiphertext()->getValue());
+        static::assertCount(0, $object->getRecipients());
+    }
+
+    #[Test]
+    public function aMacStructureExposesItsTagAndItsRecipients(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d8618540a0436162634374616780')));
+
+        static::assertInstanceOf(CoseMacTag::class, $object);
+        static::assertSame('abc', $object->getPayload()->getValue());
+        static::assertSame('tag', $object->getTag()->getValue());
+        static::assertCount(0, $object->getRecipients());
+    }
+
+    #[Test]
+    public function aWebTokenAcceptsAnUnsecuredClaimsSet(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d83da10102')));
+
+        static::assertInstanceOf(CwtTag::class, $object);
+        static::assertSame([
+            1 => '2',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function aWebTokenThatIsNeitherAClaimsSetNorACoseStructureIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Map object, a List object or a COSE tag.');
+        CwtTag::create(TextStringObject::create('not a token'));
+    }
+}

--- a/tests/Tag/DateTagTest.php
+++ b/tests/Tag/DateTagTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\Normalizable;
+use CBOR\StringStream;
+use CBOR\Tag\DateStringTag;
+use CBOR\Tag\DateTag;
+use CBOR\Test\CBORTestCase;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
+use DateTimeInterface;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The two date tags of RFC 8943: 100, a number of days since the epoch, and 1004, an RFC 3339 full-date.
+ *
+ * Both denote a calendar day rather than an instant, and both are normalized to midnight UTC -- the only
+ * reading that keeps the day intact, since PHP has no date-only type.
+ *
+ * @internal
+ */
+final class DateTagTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function dates(): iterable
+    {
+        yield 'the epoch itself' => ['d86400', '1970-01-01'];
+        yield 'a day after the epoch' => ['d864194d2f', '2024-02-06'];
+        yield 'a day before the epoch' => ['d86420', '1969-12-31'];
+        yield 'a full-date string' => ['d903ec6a323032342d30312d3135', '2024-01-15'];
+        yield 'a leap day' => ['d903ec6a323032342d30322d3239', '2024-02-29'];
+    }
+
+    #[DataProvider('dates')]
+    #[Test]
+    public function aDateIsNormalizedToMidnightUtc(string $data, string $expected): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($data)));
+
+        static::assertInstanceOf(Normalizable::class, $object);
+        $date = $object->normalize();
+
+        static::assertInstanceOf(DateTimeInterface::class, $date);
+        static::assertSame($expected . ' 00:00:00 +00:00', $date->format('Y-m-d H:i:s P'));
+    }
+
+    #[Test]
+    public function aDayCountThatNoDateCanHoldIsRejected(): void
+    {
+        // 100(18446744073709551615)
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d8641bffffffffffffffff')));
+
+        static::assertInstanceOf(DateTag::class, $object);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+        $object->normalize();
+    }
+
+    #[Test]
+    public function aDayCountThatIsNotAnIntegerIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts an Integer object.');
+        DateTag::create(TextStringObject::create('2024-01-15'));
+    }
+
+    /**
+     * createFromFormat() rolls a day that does not exist over into the next month instead of rejecting it, so
+     * the warning it raises is what tells the two apart.
+     */
+    #[Test]
+    public function aDayThatDoesNotExistIsRejected(): void
+    {
+        $tag = DateStringTag::create(TextStringObject::create('2013-02-30'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+        $tag->normalize();
+    }
+
+    #[Test]
+    public function aDateStringWithATimeIsRejected(): void
+    {
+        $tag = DateStringTag::create(TextStringObject::create('2024-01-15T10:30:00Z'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot be converted into a datetime object');
+        $tag->normalize();
+    }
+
+    #[Test]
+    public function aDateStringThatIsNotTextIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Text String object.');
+        DateStringTag::create(ByteStringObject::create('2024-01-15'));
+    }
+
+    /**
+     * The day is the same wherever the process happens to be running: a date tag carries no time zone, so the
+     * ambient one must not leak into the value.
+     */
+    #[Test]
+    public function theDefaultTimeZoneDoesNotMoveTheDay(): void
+    {
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        try {
+            $tag = DateStringTag::create(TextStringObject::create('2024-01-15'));
+            static::assertSame('2024-01-15', $tag->normalize()->format('Y-m-d'));
+
+            $day = DateTag::create(UnsignedIntegerObject::create(19737));
+            static::assertSame('2024-01-15', $day->normalize()->format('Y-m-d'));
+        } finally {
+            date_default_timezone_set($timezone);
+        }
+    }
+}

--- a/tests/Tag/DefaultTagManagerTest.php
+++ b/tests/Tag/DefaultTagManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CBOR\Test\Tag;
 
 use CBOR\CBORObject;
+use CBOR\Decoder;
 use CBOR\Normalizable;
 use CBOR\StringStream;
 use CBOR\Tag\Base16EncodingTag;
@@ -27,8 +28,11 @@ use CBOR\Tag\UnsignedBigIntegerTag;
 use CBOR\Tag\UriTag;
 use CBOR\Test\CBORTestCase;
 use CBOR\TextStringObject;
+use function hex2bin;
+use function is_subclass_of;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClassConstant;
 
 /**
  * The default tag manager used by the decoder must resolve every built-in tag class by its registered
@@ -182,5 +186,37 @@ final class DefaultTagManagerTest extends CBORTestCase
 
         static::assertInstanceOf(UriTag::class, $object);
         static::assertSame('http://www.example.com', $object->normalize());
+    }
+
+    /**
+     * The decoder names its tag classes by number rather than asking each of them, so that a manager holding the
+     * whole registry does not load a hundred classes before the first byte is read. Nothing checks that a class
+     * agrees with the number it is filed under -- checking is what loading would be -- so it is checked here.
+     */
+    #[Test]
+    public function everyTagOfTheDefaultRegistryIsFiledUnderItsOwnTagNumber(): void
+    {
+        /** @var array<int, class-string<TagInterface>> $tags */
+        $tags = (new ReflectionClassConstant(Decoder::class, 'DEFAULT_TAGS'))->getValue();
+
+        static::assertNotEmpty($tags);
+        foreach ($tags as $tagId => $class) {
+            static::assertTrue(is_subclass_of($class, TagInterface::class), $class . ' is not a tag class.');
+            static::assertSame($tagId, $class::getTagId(), $class . ' is filed under the wrong tag number.');
+        }
+    }
+
+    /**
+     * A tag class the decoder does not know about is left to the generic handler, which keeps the number and the
+     * item without pretending to understand either.
+     */
+    #[Test]
+    public function aTagNumberOutsideTheDefaultRegistryIsDecodedAsAGenericTag(): void
+    {
+        // 4711(1), which the IANA registry leaves unassigned.
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d9126701')));
+
+        static::assertInstanceOf(GenericTag::class, $object);
     }
 }

--- a/tests/Tag/IpAddressTagTest.php
+++ b/tests/Tag/IpAddressTagTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\Normalizable;
+use CBOR\StringStream;
+use CBOR\Tag\Ipv4Tag;
+use CBOR\Tag\Ipv6Tag;
+use CBOR\Tag\NetworkAddressPrefixTag;
+use CBOR\Tag\NetworkAddressTag;
+use CBOR\Test\CBORTestCase;
+use CBOR\UnsignedIntegerObject;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use function str_replace;
+
+/**
+ * The address tags of RFC 9164 (52 and 54) and the two earlier ones they replaced (260 and 261).
+ *
+ * @internal
+ */
+final class IpAddressTagTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function addresses(): iterable
+    {
+        yield 'an IPv4 address' => ['d8344401020304', '1.2.3.4'];
+        // 52([24, h'0a0a0a']): the trailing zero byte of the prefix is left out.
+        yield 'an IPv4 prefix' => ['d834821818430a0a0a', '10.10.10.0/24'];
+        // 52([h'01020304', "eth0"]).
+        yield 'an IPv4 address with a zone' => ['d834824401020304646574 6830', '1.2.3.4%eth0'];
+        yield 'an IPv6 address' => ['d8365020010db8000000000000000000000000', '2001:db8::'];
+        yield 'an IPv6 prefix' => ['d8368218204420010db8', '2001:db8::/32'];
+        yield 'a legacy IPv4 address' => ['d901044401020304', '1.2.3.4'];
+        yield 'a legacy MAC address' => ['d9010446010203040506', '01:02:03:04:05:06'];
+        yield 'a legacy IPv6 address' => ['d901045020010db8000000000000000000000000', '2001:db8::'];
+    }
+
+    #[DataProvider('addresses')]
+    #[Test]
+    public function anAddressIsNormalizedIntoItsTextualForm(string $data, string $expected): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin(str_replace(' ', '', $data))));
+
+        static::assertInstanceOf(Normalizable::class, $object);
+        static::assertSame($expected, $object->normalize());
+    }
+
+    #[Test]
+    public function anAddressOfTheWrongSizeIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a 4 byte Byte String object as an address.');
+        Ipv4Tag::create(ByteStringObject::create("\x01\x02\x03"));
+    }
+
+    #[Test]
+    public function aPrefixLongerThanTheAddressFamilyAllowsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid prefix length. Expected at most 32.');
+        Ipv4Tag::create(ListObject::create([
+            UnsignedIntegerObject::create(33),
+            ByteStringObject::create("\x0a"),
+        ]));
+    }
+
+    #[Test]
+    public function aPrefixWithMoreBytesThanTheAddressFamilyAllowsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid prefix. Expected at most 4 bytes.');
+        Ipv4Tag::create(ListObject::create([
+            UnsignedIntegerObject::create(24),
+            ByteStringObject::create("\x0a\x0a\x0a\x0a\x0a"),
+        ]));
+    }
+
+    #[Test]
+    public function anAddressIsBuiltFromItsTextualForm(): void
+    {
+        static::assertSame('192.0.2.1', Ipv4Tag::createFromAddress('192.0.2.1')->normalize());
+        static::assertSame('2001:db8::1', Ipv6Tag::createFromAddress('2001:db8::1')->normalize());
+    }
+
+    #[Test]
+    public function aTextThatIsNotAnAddressOfThatFamilyIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value is not a valid IPv4 address.');
+        Ipv4Tag::createFromAddress('2001:db8::1');
+    }
+
+    #[Test]
+    public function aLegacyAddressOfAnUnknownSizeIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a 4, 6 or 16 byte Byte String object.');
+        NetworkAddressTag::create(ByteStringObject::create("\x01\x02\x03"));
+    }
+
+    #[Test]
+    public function aLegacyPrefixIsTheSingleEntryMapItIs(): void
+    {
+        // 261({h'0a0a0a00': 24})
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d90105a1440a0a0a001818')));
+
+        static::assertInstanceOf(NetworkAddressPrefixTag::class, $object);
+        static::assertSame([
+            "\x0a\x0a\x0a\x00" => '24',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function aLegacyPrefixWithMoreThanOneEntryIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Map object that contains 1 item.');
+        NetworkAddressPrefixTag::create(MapObject::create());
+    }
+}

--- a/tests/Tag/RegistryTagsTest.php
+++ b/tests/Tag/RegistryTagsTest.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\BinaryMimeTag;
+use CBOR\Tag\DurationTag;
+use CBOR\Tag\ExplicitMapTag;
+use CBOR\Tag\ExtendedTimeTag;
+use CBOR\Tag\HomogeneousArrayTag;
+use CBOR\Tag\IdentifierTag;
+use CBOR\Tag\IpldContentIdentifierTag;
+use CBOR\Tag\LanguageIndependentObjectTag;
+use CBOR\Tag\LanguageTaggedStringTag;
+use CBOR\Tag\PeriodTag;
+use CBOR\Tag\PerlObjectTag;
+use CBOR\Tag\RationalNumberTag;
+use CBOR\Tag\RegexpTag;
+use CBOR\Tag\SetTag;
+use CBOR\Tag\ShareableTag;
+use CBOR\Tag\SharedReferenceTag;
+use CBOR\Tag\StringReferenceNamespaceTag;
+use CBOR\Tag\StringReferenceTag;
+use CBOR\Tag\TagInterface;
+use CBOR\Tag\UuidTag;
+use CBOR\Test\CBORTestCase;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The tags of the IANA registry that this library implements outside of RFC 8949, the typed arrays, the COSE
+ * structures and the address tags -- each of which has a test case of its own.
+ *
+ * @internal
+ */
+final class RegistryTagsTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, class-string<TagInterface>}>
+     */
+    public static function taggedDocuments(): iterable
+    {
+        yield 'tag 25 (string reference)' => ['d81901', StringReferenceTag::class];
+        yield 'tag 26 (perl object)' => ['d81a8263466f6f01', PerlObjectTag::class];
+        yield 'tag 27 (language independent object)' => ['d81b8263466f6f01', LanguageIndependentObjectTag::class];
+        yield 'tag 28 (shareable)' => ['d81c01', ShareableTag::class];
+        yield 'tag 29 (shared reference)' => ['d81d00', SharedReferenceTag::class];
+        yield 'tag 30 (rational number)' => ['d81e820304', RationalNumberTag::class];
+        yield 'tag 35 (regular expression)' => ['d82363616263', RegexpTag::class];
+        yield 'tag 37 (uuid)' => ['d82550000102030405060708090a0b0c0d0e0f', UuidTag::class];
+        yield 'tag 38 (language tagged string)' => ['d8268262656e63616263', LanguageTaggedStringTag::class];
+        yield 'tag 39 (identifier)' => ['d82701', IdentifierTag::class];
+        yield 'tag 41 (homogeneous array)' => ['d82983010203', HomogeneousArrayTag::class];
+        yield 'tag 42 (IPLD content identifier)' => ['d82a43000102', IpldContentIdentifierTag::class];
+        yield 'tag 256 (string reference namespace)' => ['d9010001', StringReferenceNamespaceTag::class];
+        yield 'tag 257 (binary MIME message)' => ['d9010143616263', BinaryMimeTag::class];
+        yield 'tag 258 (set)' => ['d9010283010203', SetTag::class];
+        yield 'tag 259 (explicit map)' => ['d90103a10102', ExplicitMapTag::class];
+        yield 'tag 1001 (extended time)' => ['d903e9a1011a05f5e100', ExtendedTimeTag::class];
+        yield 'tag 1002 (duration)' => ['d903eaa101183c', DurationTag::class];
+        yield 'tag 1003 (period)' => ['d903eb820102', PeriodTag::class];
+    }
+
+    /**
+     * @param class-string<TagInterface> $class
+     */
+    #[DataProvider('taggedDocuments')]
+    #[Test]
+    public function theDecoderCreatesTheTagClassRegisteredForTheTagNumber(string $data, string $class): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($data)));
+
+        static::assertInstanceOf($class, $object);
+    }
+
+    #[Test]
+    public function aUuidIsNormalizedToItsCanonicalForm(): void
+    {
+        $tag = UuidTag::createFromUuidString('01234567-89AB-CDEF-0123-456789ABCDEF');
+
+        static::assertSame('01234567-89ab-cdef-0123-456789abcdef', $tag->normalize());
+        static::assertSame(
+            'd825500123456789abcdef0123456789abcdef',
+            bin2hex((string) $tag)
+        );
+    }
+
+    #[Test]
+    public function aUuidThatIsNotSixteenBytesIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a 16 byte Byte String object.');
+        UuidTag::create(ByteStringObject::create('too short'));
+    }
+
+    #[Test]
+    public function aTextThatIsNotAUuidIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value is not a valid UUID.');
+        UuidTag::createFromUuidString('not a uuid');
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function rationalNumbers(): iterable
+    {
+        yield 'already in lowest terms' => ['d81e820304', '3/4'];
+        yield 'reduced' => ['d81e820604', '3/2'];
+        yield 'integral' => ['d81e820402', '2'];
+        yield 'zero' => ['d81e820003', '0'];
+        yield 'negative numerator' => ['d81e822004', '-1/4'];
+        // 30([2, 18446744073709551617]), i.e. a denominator beyond PHP_INT_MAX carried by tag 2.
+        yield 'big denominator' => ['d81e8202c249010000000000000001', '2/18446744073709551617'];
+    }
+
+    #[DataProvider('rationalNumbers')]
+    #[Test]
+    public function aRationalNumberIsNormalizedInLowestTerms(string $data, string $expected): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin($data)));
+
+        static::assertInstanceOf(RationalNumberTag::class, $object);
+        static::assertSame($expected, $object->normalize());
+    }
+
+    #[Test]
+    public function aRationalNumberWithAZeroDenominatorIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value shall not be zero.');
+        RationalNumberTag::create(ListObject::create([
+            UnsignedIntegerObject::create(1),
+            UnsignedIntegerObject::create(0),
+        ]));
+    }
+
+    #[Test]
+    public function aRationalNumberWithASignedDenominatorIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid denominator.');
+        RationalNumberTag::create(ListObject::create([
+            UnsignedIntegerObject::create(1),
+            NegativeIntegerObject::create(-2),
+        ]));
+    }
+
+    #[Test]
+    public function aLanguageTaggedStringExposesItsTwoParts(): void
+    {
+        $tag = LanguageTaggedStringTag::createFromLanguageAndText('fr-CA', 'bonjour');
+
+        static::assertSame('fr-CA', $tag->getLanguage());
+        static::assertSame('bonjour', $tag->getText());
+        static::assertSame(['fr-CA', 'bonjour'], $tag->normalize());
+    }
+
+    #[Test]
+    public function aSerializedObjectExposesItsClassName(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d81a8263466f6f01')));
+
+        static::assertInstanceOf(PerlObjectTag::class, $object);
+        static::assertSame('Foo', $object->getClassName());
+        static::assertSame(['Foo', '1'], $object->normalize());
+    }
+
+    #[Test]
+    public function aSerializedObjectWithoutAClassNameIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least 1 item');
+        PerlObjectTag::create(ListObject::create([]));
+    }
+
+    #[Test]
+    public function aSetKeepsTheOrderItWasWrittenIn(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d9010283030102')));
+
+        static::assertInstanceOf(SetTag::class, $object);
+        static::assertSame(['3', '1', '2'], $object->normalize());
+    }
+
+    #[Test]
+    public function aSetThatIsNotAnArrayIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a List object.');
+        SetTag::create(TextStringObject::create('not an array'));
+    }
+
+    #[Test]
+    public function anExplicitMapIsNormalizedAsAMap(): void
+    {
+        $tag = ExplicitMapTag::create(
+            MapObject::create()->add(TextStringObject::create('key'), TextStringObject::create('value'))
+        );
+
+        static::assertSame([
+            'key' => 'value',
+        ], $tag->normalize());
+    }
+
+    #[Test]
+    public function aShareableTagNormalizesTheItemItMarks(): void
+    {
+        $tag = ShareableTag::create(TextStringObject::create('shared'));
+
+        static::assertSame('shared', $tag->normalize());
+    }
+
+    #[Test]
+    public function aStringReferenceIsNormalizedToItsIndex(): void
+    {
+        $tag = StringReferenceTag::create(UnsignedIntegerObject::create(7));
+
+        static::assertSame('7', $tag->normalize());
+    }
+
+    #[Test]
+    public function aStringReferenceThatIsNotAnIndexIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts an Unsigned Integer object.');
+        SharedReferenceTag::create(NegativeIntegerObject::create(-1));
+    }
+
+    #[Test]
+    public function aRegularExpressionIsCarriedAsItIsWritten(): void
+    {
+        $tag = RegexpTag::create(TextStringObject::create('^[a-z]+$'));
+
+        static::assertSame('^[a-z]+$', $tag->normalize());
+    }
+
+    #[Test]
+    public function aRegularExpressionThatIsNotTextIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Text String object.');
+        RegexpTag::create(ByteStringObject::create('^[a-z]+$'));
+    }
+
+    #[Test]
+    public function aBinaryMimeMessageIsCarriedAsBytes(): void
+    {
+        $tag = BinaryMimeTag::create(ByteStringObject::create("Content-Type: text/plain\r\n\r\n\xff"));
+
+        static::assertSame("Content-Type: text/plain\r\n\r\n\xff", $tag->normalize());
+    }
+
+    #[Test]
+    public function anHomogeneousArrayIsNormalizedAsAnArray(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d82983010203')));
+
+        static::assertInstanceOf(HomogeneousArrayTag::class, $object);
+        static::assertSame(['1', '2', '3'], $object->normalize());
+    }
+
+    #[Test]
+    public function anExtendedTimeIsReturnedAsTheMapItIs(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d903e9a1011a05f5e100')));
+
+        static::assertInstanceOf(ExtendedTimeTag::class, $object);
+        static::assertSame([
+            1 => '100000000',
+        ], $object->normalize());
+    }
+
+    #[Test]
+    public function anExtendedTimeThatIsNotAMapIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Map object.');
+        ExtendedTimeTag::create(ListObject::create([]));
+    }
+
+    #[Test]
+    public function anIdentifierNormalizesTheItemItMarks(): void
+    {
+        $tag = IdentifierTag::create(TextStringObject::create('name'));
+
+        static::assertSame('name', $tag->normalize());
+    }
+
+    #[Test]
+    public function aPeriodIsReturnedAsTheArrayItIs(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d903eb820102')));
+
+        static::assertInstanceOf(PeriodTag::class, $object);
+        static::assertSame(['1', '2'], $object->normalize());
+    }
+
+    #[Test]
+    public function anIpldContentIdentifierIsCarriedAsBytes(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d82a43000102')));
+
+        static::assertInstanceOf(IpldContentIdentifierTag::class, $object);
+        static::assertSame("\x00\x01\x02", $object->normalize());
+    }
+}

--- a/tests/Tag/TypedArrayTagTest.php
+++ b/tests/Tag/TypedArrayTagTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test\Tag;
+
+use function array_map;
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\Normalizable;
+use CBOR\StringStream;
+use CBOR\Tag\ColumnMajorMultiDimensionalArrayTag;
+use CBOR\Tag\RowMajorMultiDimensionalArrayTag;
+use CBOR\Tag\TypedArray\AbstractTypedArrayTag;
+use CBOR\Tag\TypedArray\Float128BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint16BigEndianArrayTag;
+use CBOR\Tag\TypedArray\Uint8ArrayTag;
+use CBOR\Test\CBORTestCase;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function count;
+use function hex2bin;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use function str_replace;
+
+/**
+ * The typed array tags of RFC 8746 (64 to 87) and the two multi-dimensional array tags (40 and 1040) that fold
+ * them into a shape.
+ *
+ * @internal
+ */
+final class TypedArrayTagTest extends CBORTestCase
+{
+    /**
+     * @return iterable<string, array{string, array<int, float|int|string>}>
+     */
+    public static function typedArrays(): iterable
+    {
+        yield 'tag 64 (uint8)' => ['d8404300ff80', [0, 255, 128]];
+        yield 'tag 68 (uint8 clamped)' => ['d8444300ff80', [0, 255, 128]];
+        yield 'tag 65 (uint16 big endian)' => ['d8414400010002', [1, 2]];
+        yield 'tag 69 (uint16 little endian)' => ['d84544010002 00', [1, 2]];
+        yield 'tag 66 (uint32 big endian)' => ['d84244ffffffff', [4294967295]];
+        yield 'tag 70 (uint32 little endian)' => ['d84644 01000000', [1]];
+        yield 'tag 67 (uint64 big endian)' => ['d84348ffffffffffffffff', ['18446744073709551615']];
+        yield 'tag 71 (uint64 little endian)' => ['d84748 0100000000000000', [1]];
+        yield 'tag 72 (sint8)' => ['d8484300ff80', [0, -1, -128]];
+        yield 'tag 73 (sint16 big endian)' => ['d84944ffff8000', [-1, -32768]];
+        yield 'tag 77 (sint16 little endian)' => ['d84d44ffff0080', [-1, -32768]];
+        yield 'tag 74 (sint32 big endian)' => ['d84a44ffffffff', [-1]];
+        yield 'tag 78 (sint32 little endian)' => ['d84e44ffffffff', [-1]];
+        yield 'tag 75 (sint64 big endian)' => ['d84b48ffffffffffffffff', [-1]];
+        yield 'tag 79 (sint64 little endian)' => ['d84f48ffffffffffffffff', [-1]];
+        yield 'tag 80 (float16 big endian)' => ['d850443c004000', [1.0, 2.0]];
+        yield 'tag 84 (float16 little endian)' => ['d85444003c0040', [1.0, 2.0]];
+        yield 'tag 81 (float32 big endian)' => ['d851443f800000', [1.0]];
+        yield 'tag 85 (float32 little endian)' => ['d85544 0000803f', [1.0]];
+        yield 'tag 82 (float64 big endian)' => ['d852483ff0000000000000', [1.0]];
+        yield 'tag 86 (float64 little endian)' => ['d85648000000000000f03f', [1.0]];
+        yield 'an empty typed array' => ['d84140', []];
+    }
+
+    /**
+     * @param array<int, float|int|string> $expected
+     */
+    #[DataProvider('typedArrays')]
+    #[Test]
+    public function aTypedArrayIsNormalizedIntoItsElements(string $data, array $expected): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin(str_replace(' ', '', $data))));
+
+        static::assertInstanceOf(AbstractTypedArrayTag::class, $object);
+        static::assertInstanceOf(Normalizable::class, $object);
+        static::assertSame($expected, $object->normalize());
+        static::assertCount(count($expected), $object);
+    }
+
+    #[Test]
+    public function aTypedArrayWhoseLengthIsNotAWholeNumberOfElementsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('whose length is a multiple of 2');
+        Uint16BigEndianArrayTag::create(ByteStringObject::create('abc'));
+    }
+
+    #[Test]
+    public function aTypedArrayThatIsNotAByteStringIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('This tag only accepts a Byte String object.');
+        Uint8ArrayTag::create(TextStringObject::create('abc'));
+    }
+
+    /**
+     * PHP has no binary128, so the tag carries the elements instead of converting them.
+     */
+    #[Test]
+    public function aBinary128ArrayHandsBackItsElementsAsBytes(): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin(
+                'd85358203fff000000000000000000000000000040000000000000000000000000000000'
+            )));
+
+        static::assertInstanceOf(Float128BigEndianArrayTag::class, $object);
+        static::assertNotInstanceOf(Normalizable::class, $object);
+        static::assertCount(2, $object);
+        static::assertSame(
+            ['3fff0000000000000000000000000000', '40000000000000000000000000000000'],
+            array_map('bin2hex', $object->getChunks())
+        );
+    }
+
+    #[Test]
+    public function aRowMajorArrayIsFoldedAlongItsLastIndexFirst(): void
+    {
+        // 40([[2, 3], [1, 2, 3, 4, 5, 6]])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d8288282020386010203040506')));
+
+        static::assertInstanceOf(RowMajorMultiDimensionalArrayTag::class, $object);
+        static::assertSame([2, 3], $object->getDimensions());
+        static::assertSame([['1', '2', '3'], ['4', '5', '6']], $object->normalize());
+    }
+
+    #[Test]
+    public function aColumnMajorArrayIsFoldedAlongItsFirstIndexFirst(): void
+    {
+        // 1040([[2, 3], [1, 2, 3, 4, 5, 6]])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d904108282020386010203040506')));
+
+        static::assertInstanceOf(ColumnMajorMultiDimensionalArrayTag::class, $object);
+        static::assertSame([['1', '3', '5'], ['2', '4', '6']], $object->normalize());
+    }
+
+    #[Test]
+    public function aMultiDimensionalArrayFoldsTheTypedArrayItPointsAt(): void
+    {
+        // 40([[2, 2], 64(h'01020304')])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d82882820202d8404401020304')));
+
+        static::assertInstanceOf(RowMajorMultiDimensionalArrayTag::class, $object);
+        static::assertSame([[1, 2], [3, 4]], $object->normalize());
+    }
+
+    #[Test]
+    public function aThreeDimensionalArrayIsFoldedAllTheWayDown(): void
+    {
+        // 40([[2, 2, 2], 64(h'0102030405060708')])
+        $object = $this->getDecoder()
+            ->decode(StringStream::create((string) hex2bin('d8288283020202d840480102030405060708')));
+
+        static::assertInstanceOf(RowMajorMultiDimensionalArrayTag::class, $object);
+        static::assertSame([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], $object->normalize());
+    }
+
+    #[Test]
+    public function aMultiDimensionalArrayWhoseDimensionsDoNotMatchItsValuesIsRejected(): void
+    {
+        $tag = RowMajorMultiDimensionalArrayTag::create(ListObject::create([
+            ListObject::create([UnsignedIntegerObject::create(2), UnsignedIntegerObject::create(3)]),
+            ListObject::create([UnsignedIntegerObject::create(1)]),
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The dimensions do not match the number of values.');
+        $tag->normalize();
+    }
+
+    #[Test]
+    public function aMultiDimensionalArrayWithoutDimensionsIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected at least one dimension.');
+        RowMajorMultiDimensionalArrayTag::create(ListObject::create([
+            ListObject::create([]),
+            ListObject::create([]),
+        ]));
+    }
+}


### PR DESCRIPTION
`doc/tags.md` advertised a tag reference that stopped at the fifteen tags of RFC 8949. Everything else in the IANA registry — UUIDs, sets, typed arrays, IP addresses, COSE structures — fell through to `GenericTag`, which keeps the number and the item but understands neither.

This adds the 58 tags that were missing, all registered in the decoder by default (73 in total).

## What is added

| Family | Tags |
|---|---|
| COSE (RFC 9052) and CWT (RFC 8392) | 16, 17, 18, 61, 96, 97, 98 |
| Typed arrays (RFC 8746), multi-dimensional and homogeneous arrays | 40, 41, 64-87, 1040 |
| Dates without a time (RFC 8943) | 100, 1004 |
| Addresses (RFC 9164, and the legacy pair) | 52, 54, 260, 261 |
| Extended time, duration, period (RFC 9581) | 1001, 1002, 1003 |
| Rest of the registry | 25, 26, 27, 28, 29, 30, 35, 37, 38, 39, 42, 63, 256, 257, 258, 259 |

A few decisions worth reviewing:

- **COSE** is ported from [web-auth/cose-lib](https://github.com/web-auth/cose-lib), which will deprecate its own classes in favour of these. Two shapes the original turns away are accepted here: a **detached payload**, which COSE writes as `null` and which is the reason COSE_Sign1 exists, and an **absent protected header**, which COSE writes as an empty byte string — `getProtectedHeaderAsMap()` answers an empty map rather than failing to parse zero bytes. Nothing is verified: signatures and MACs need keys and algorithms that belong to a COSE implementation.
- **binary128 typed arrays** (83, 87) carry their elements rather than normalizing them. PHP has no quadruple precision float, and returning a binary64 would quietly drop fifteen digits, so they do not implement `Normalizable`; `getChunks()` hands back the 16 bytes of each element.
- **Dates 100 and 1004** normalize to midnight UTC, so the ambient time zone cannot move the day. A day that does not exist (`2013-02-30`) is rejected rather than rolled over.
- **RFC 9581 time** is returned as the map or array it is: a leap second, a time scale that is not UTC or a resolution below the microsecond do not all fit `DateTimeImmutable`, and flattening them would drop whichever does not.
- **String references and value sharing** (25, 28, 29, 256) are recorded, not resolved: the table a reference points into is built while the whole document is read, which is outside the scope of any single tag.

## Lazy registration

Registering seventy-odd classes must not cost seventy autoloads before the first byte is read. `TagManager::register()` files a class under a tag number without asking the class for it, and the decoder builds its default manager that way. `add()` is untouched.

The check registration can no longer make is made by a test instead: it walks the default map and asserts that every class agrees with the number it is filed under.

## Behaviour change

A document whose tagged item does not match the tag definition — a set that is not an array, a URI that is not a text string — is now rejected with an `InvalidArgumentException` where 3.3 returned a `GenericTag`. This is the contract the library already applied to tags 0-5 and 32-36, but it is a change worth calling out in the release notes.

## Along the way

- The annotations of `ListObject` and `IndefiniteLengthListObject` now say their keys are integers, which is what they hold and what the new tags needed in order to type their own `normalize()`. The `ListObject` baseline entry that the imprecision required is gone.
- The COSE example of `doc/custom-tags.md` gave tag 98 twice, called tag 18 "COSE Sign" and built a `COSESign1Tag` numbered 98. It now points at what the library ships.
- `doc/tags.md` gains five sections and a complete summary table, plus a section on what is *not* implemented and how `GenericTag` covers it.

## Checks

`castor ecs`, `castor rector`, `castor phpstan` (level max, no new baseline entry), `castor deptrac` and `castor phpunit` (961 tests, 2111 assertions) all pass.