### PR TITLE
perf(decode): read head arguments natively and defer string length heads

### DIFF
--- a/src/ByteStringObject.php
+++ b/src/ByteStringObject.php
@@ -13,25 +13,30 @@ final class ByteStringObject extends AbstractCBORObject implements Normalizable
 {
     private const MAJOR_TYPE = self::MAJOR_TYPE_BYTE_STRING;
 
-    private string $value;
+    private ?string $length = null;
 
-    private ?string $length;
+    private bool $lengthComputed = false;
 
-    public function __construct(string $data)
-    {
-        [$additionalInformation, $length] = LengthCalculator::getLengthOfString($data);
-
-        parent::__construct(self::MAJOR_TYPE, $additionalInformation);
-        $this->length = $length;
-        $this->value = $data;
+    public function __construct(
+        private string $value
+    ) {
+        parent::__construct(self::MAJOR_TYPE, 0);
     }
 
     public function __toString(): string
     {
+        $this->computeLength();
         $result = parent::__toString();
         $result .= $this->length ?? '';
 
         return $result . $this->value;
+    }
+
+    public function getAdditionalInformation(): int
+    {
+        $this->computeLength();
+
+        return parent::getAdditionalInformation();
     }
 
     public static function create(string $data): self
@@ -52,5 +57,20 @@ final class ByteStringObject extends AbstractCBORObject implements Normalizable
     public function normalize(): string
     {
         return $this->value;
+    }
+
+    /**
+     * A string object is immutable, so its head never changes -- but decoding never asks for it: the object is built
+     * from the payload and read back through normalize(), and only re-encoding calls __toString(). Computing it up
+     * front made every decoded string pay for a head nobody reads.
+     */
+    private function computeLength(): void
+    {
+        if ($this->lengthComputed) {
+            return;
+        }
+
+        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfString($this->value);
+        $this->lengthComputed = true;
     }
 }

--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -98,7 +98,13 @@ final class Decoder implements DecoderInterface
             case CBORObject::LENGTH_2_BYTES: // 25
             case CBORObject::LENGTH_4_BYTES: // 26
             case CBORObject::LENGTH_8_BYTES: // 27
-                $val = $stream->read(2 ** ($ai & 0b00000111));
+                // 24..27 carry 1, 2, 4 and 8 bytes of argument; a table beats a float exponentiation per head.
+                $val = $stream->read(match ($ai) {
+                    CBORObject::LENGTH_1_BYTE => 1,
+                    CBORObject::LENGTH_2_BYTES => 2,
+                    CBORObject::LENGTH_4_BYTES => 4,
+                    default => 8,
+                });
                 break;
             case CBORObject::FUTURE_USE_1: // 28
             case CBORObject::FUTURE_USE_2: // 29

--- a/src/TextStringObject.php
+++ b/src/TextStringObject.php
@@ -11,25 +11,30 @@ final class TextStringObject extends AbstractCBORObject implements Normalizable
 {
     private const MAJOR_TYPE = self::MAJOR_TYPE_TEXT_STRING;
 
-    private ?string $length;
+    private ?string $length = null;
 
-    private string $data;
+    private bool $lengthComputed = false;
 
-    public function __construct(string $data)
-    {
-        [$additionalInformation, $length] = LengthCalculator::getLengthOfString($data);
-
-        parent::__construct(self::MAJOR_TYPE, $additionalInformation);
-        $this->data = $data;
-        $this->length = $length;
+    public function __construct(
+        private string $data
+    ) {
+        parent::__construct(self::MAJOR_TYPE, 0);
     }
 
     public function __toString(): string
     {
+        $this->computeLength();
         $result = parent::__toString();
         $result .= $this->length ?? '';
 
         return $result . $this->data;
+    }
+
+    public function getAdditionalInformation(): int
+    {
+        $this->computeLength();
+
+        return parent::getAdditionalInformation();
     }
 
     public static function create(string $data): self
@@ -50,5 +55,20 @@ final class TextStringObject extends AbstractCBORObject implements Normalizable
     public function normalize(): string
     {
         return $this->data;
+    }
+
+    /**
+     * A string object is immutable, so its head never changes -- but decoding never asks for it: the object is built
+     * from the payload and read back through normalize(), and only re-encoding calls __toString(). Computing it up
+     * front made every decoded string pay for a head nobody reads.
+     */
+    private function computeLength(): void
+    {
+        if ($this->lengthComputed) {
+            return;
+        }
+
+        [$this->additionalInformation, $this->length] = LengthCalculator::getLengthOfString($this->data);
+        $this->lengthComputed = true;
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -9,7 +9,9 @@ use Brick\Math\Exception\IntegerOverflowException;
 use Brick\Math\Exception\MathException;
 use InvalidArgumentException;
 use function is_string;
+use function ord;
 use function sprintf;
+use function strlen;
 
 /**
  * @internal
@@ -18,6 +20,21 @@ abstract class Utils
 {
     public static function binToInt(string $value): int
     {
+        // A CBOR head argument is at most 8 bytes and nearly always fits a PHP integer, so build it from the bytes
+        // and keep brick/math for the one case that does not: an argument above PHP_INT_MAX, which wraps negative
+        // here and is handed over below for the range error.
+        $length = strlen($value);
+        if ($length <= 8) {
+            $result = 0;
+            for ($i = 0; $i < $length; ++$i) {
+                $result = ($result << 8) | ord($value[$i]);
+            }
+
+            if ($result >= 0) {
+                return $result;
+            }
+        }
+
         return self::bigIntegerToInt(self::binToBigInteger($value));
     }
 

--- a/tests/BinToIntTest.php
+++ b/tests/BinToIntTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\StringStream;
+use CBOR\Utils;
+use InvalidArgumentException;
+use Iterator;
+use const PHP_INT_MAX;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use function sprintf;
+
+/**
+ * Utils::binToInt() reads a head argument, which the decoder does for every length and count of 24 or more.
+ *
+ * It used to hand every one of them to brick/math. The arguments that fit a PHP integer are now built from their
+ * bytes; brick/math is kept for the ones above PHP_INT_MAX, which still have to be refused with the documented
+ * message rather than silently wrapping negative.
+ *
+ * @internal
+ */
+final class BinToIntTest extends CBORTestCase
+{
+    #[DataProvider('getArgument')]
+    #[Test]
+    public function anArgumentWithinRangeIsRead(string $payload, int $expected): void
+    {
+        static::assertSame($expected, Utils::binToInt(hex2bin($payload)));
+    }
+
+    public static function getArgument(): Iterator
+    {
+        yield 'one byte, zero' => ['00', 0];
+        yield 'one byte' => ['18', 24];
+        yield 'one byte, largest' => ['ff', 255];
+        yield 'two bytes' => ['0100', 256];
+        yield 'two bytes, largest' => ['ffff', 65_535];
+        yield 'four bytes' => ['00010000', 65_536];
+        yield 'four bytes, largest' => ['ffffffff', 4_294_967_295];
+        yield 'eight bytes' => ['0000000100000000', 4_294_967_296];
+        yield 'eight bytes, PHP_INT_MAX' => ['7fffffffffffffff', PHP_INT_MAX];
+        yield 'leading zero bytes' => ['0000000000000001', 1];
+    }
+
+    /**
+     * PHP_INT_MAX + 1 is where the byte-wise read wraps negative and brick/math has to take over.
+     */
+    #[DataProvider('getOutOfRangeArgument')]
+    #[Test]
+    public function anArgumentAbovePhpIntMaxIsRefused(string $payload, string $expectedValueInMessage): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Out of range. "%s" cannot be represented as a PHP integer.',
+            $expectedValueInMessage
+        ));
+        Utils::binToInt(hex2bin($payload));
+    }
+
+    public static function getOutOfRangeArgument(): Iterator
+    {
+        yield 'PHP_INT_MAX + 1' => ['8000000000000000', '9223372036854775808'];
+        yield 'largest 64-bit argument' => ['ffffffffffffffff', '18446744073709551615'];
+    }
+
+    /**
+     * The decoder surfaces the same refusal for a byte string announcing an unrepresentable length.
+     */
+    #[Test]
+    public function aLengthAbovePhpIntMaxIsRefusedByTheDecoder(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Out of range. "18446744073709551615" cannot be represented as a PHP integer.'
+        );
+        $this->getDecoder()
+            ->decode(StringStream::create(hex2bin('5bffffffffffffffff')))
+        ;
+    }
+}

--- a/tests/LazyStringHeadTest.php
+++ b/tests/LazyStringHeadTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CBOR\Test;
+
+use CBOR\ByteStringObject;
+use CBOR\StringStream;
+use CBOR\TextStringObject;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A string object computes its length head only when that head is observed.
+ *
+ * The payload is fixed at construction, so unlike a container the head can never go stale -- it is computed once and
+ * kept. What these tests pin down is that both observers, __toString() and getAdditionalInformation(), see it, in
+ * either order, and that the encoding is unchanged across the width boundaries.
+ *
+ * @internal
+ */
+final class LazyStringHeadTest extends CBORTestCase
+{
+    #[DataProvider('getPayloadLength')]
+    #[Test]
+    public function aTextStringReportsItsHeadWithoutBeingEncodedFirst(
+        int $length,
+        int $expectedAdditionalInformation
+    ): void {
+        $object = TextStringObject::create(str_repeat('a', $length));
+
+        static::assertSame($expectedAdditionalInformation, $object->getAdditionalInformation());
+    }
+
+    #[DataProvider('getPayloadLength')]
+    #[Test]
+    public function aByteStringReportsItsHeadWithoutBeingEncodedFirst(
+        int $length,
+        int $expectedAdditionalInformation
+    ): void {
+        $object = ByteStringObject::create(str_repeat("\x01", $length));
+
+        static::assertSame($expectedAdditionalInformation, $object->getAdditionalInformation());
+    }
+
+    /**
+     * The head widens at 24 bytes, then at 256.
+     */
+    public static function getPayloadLength(): Iterator
+    {
+        yield 'empty' => [0, 0];
+        yield 'one byte' => [1, 1];
+        yield 'last inline length' => [23, 23];
+        yield 'first one-byte length' => [24, 24];
+        yield 'last one-byte length' => [255, 24];
+        yield 'first two-byte length' => [256, 25];
+    }
+
+    #[DataProvider('getEncodedPayload')]
+    #[Test]
+    public function aTextStringEncodesToTheSameBytesWhicheverObserverComesFirst(
+        int $length,
+        string $expectedHead
+    ): void {
+        $payload = str_repeat('a', $length);
+
+        $encodedFirst = bin2hex((string) TextStringObject::create($payload));
+
+        $headFirst = TextStringObject::create($payload);
+        $headFirst->getAdditionalInformation();
+
+        static::assertStringStartsWith($expectedHead, $encodedFirst);
+        static::assertSame($encodedFirst, bin2hex((string) $headFirst));
+    }
+
+    public static function getEncodedPayload(): Iterator
+    {
+        yield 'inline length' => [5, '65'];
+        yield 'one-byte length' => [24, '7818'];
+        yield 'two-byte length' => [256, '790100'];
+    }
+
+    /**
+     * Asking twice must not compute twice, nor return something different the second time.
+     */
+    #[Test]
+    public function theHeadIsStableAcrossRepeatedReads(): void
+    {
+        $object = TextStringObject::create(str_repeat('a', 24));
+
+        static::assertSame(24, $object->getAdditionalInformation());
+        static::assertSame(24, $object->getAdditionalInformation());
+        static::assertSame('7818' . str_repeat('61', 24), bin2hex((string) $object));
+        static::assertSame(24, $object->getAdditionalInformation());
+    }
+
+    /**
+     * A decoded string is the case the laziness is for: it is built from the payload and read back through
+     * normalize(), so the head is never needed -- but re-encoding it still has to produce the original bytes.
+     */
+    #[DataProvider('getRoundTrip')]
+    #[Test]
+    public function aDecodedStringReEncodesToItsOriginalBytes(string $encoded, string $expectedValue): void
+    {
+        $object = $this->getDecoder()
+            ->decode(StringStream::create(hex2bin($encoded)))
+        ;
+
+        static::assertSame($expectedValue, $object->normalize());
+        static::assertSame($encoded, bin2hex((string) $object));
+    }
+
+    public static function getRoundTrip(): Iterator
+    {
+        yield 'inline text' => ['6161', 'a'];
+        yield 'one-byte text' => ['7818' . str_repeat('61', 24), str_repeat('a', 24)];
+        yield 'two-byte text' => ['790100' . str_repeat('61', 256), str_repeat('a', 256)];
+        yield 'inline bytes' => ['4101', "\x01"];
+        yield 'one-byte bytes' => ['5818' . str_repeat('01', 24), str_repeat("\x01", 24)];
+    }
+}


### PR DESCRIPTION
Continues #155, #163 and #164, and picks up the two items #165 left open on the decode side.

Re-profiling the tip found two costs that are **invisible on payloads made of short strings and dominant as soon as a string or container reaches 24 items** — which is most real data.

## 1. `Utils::binToInt()` was still on the hot path

It reads the argument of every head of 24 or more — every string length, every list and map count — and handed each one to brick/math:

```php
return self::bigIntegerToInt(self::binToBigInteger($value));   // bin2hex + BigInteger::fromBase + toInt
```

Arguments that fit a PHP integer are built from their bytes now. brick/math is kept for the ones above `PHP_INT_MAX`, which still have to be refused with the documented range message rather than wrapping negative.

This is why my earlier "brick/math is down to 0.2%" reading was incomplete: it was measured on the benchmark cells, whose strings are 3–16 characters, so the length rides in the additional information and `binToInt()` is called 205 times in total. Give it 100-character strings and it is called once per string.

## 2. String objects computed a head nobody reads

`TextStringObject` and `ByteStringObject` computed their length head in the constructor. A decoded string never needs it — it is built from the payload and read back through `normalize()`, and only re-encoding calls `__toString()`. It is computed on first observation now; the payload is fixed at construction, so unlike a container it can never go stale.

## 3. Minor

`Decoder::process()` sized its argument read with `2 ** ($ai & 0b00000111)` — a float exponentiation per head — replaced by the four-entry table it is.

## Result

**10k strings of 100 characters** (a shape where every head carries an argument):

| | 3.3.x | this PR |
|---|---|---|
| decode + normalize | 32.4–32.9 ms | **12.9 ms** (2.5×) |
| encode | 12.8 ms | 13.5 ms |

Isolating them: `binToInt()` alone takes decoding from ~32.5 ms to ~16.9 ms, the deferred heads take it from there to ~12.9 ms.

**GLD.SerializerBenchmark cells** (#148), whose strings are 3–16 characters:

| | 3.3.x | this PR |
|---|---|---|
| deserialization | 37.5–38.0 ms | **34.1–34.4 ms** (−9%) |
| serialization | 33.8–34.9 ms | 34.4–34.6 ms |

Encoded output is byte for byte identical on both workloads.

### The trade-off, stated plainly

Deferring the head costs the encode path a call per string, since encoding always needs it. On the benchmark cells that shows up as roughly **+1% on serialization**; on the long-string workload it is within noise. Decoding gains far more than that in both. If you would rather not pay it, dropping the two string files from this PR keeps the `binToInt()` win, which is the larger half.

## Tests

- `tests/BinToIntTest.php` — arguments of 1, 2, 4 and 8 bytes including each width's largest, leading zero bytes, `PHP_INT_MAX`, and the two above it that must still raise `Out of range. "…" cannot be represented as a PHP integer.`, plus the same refusal surfaced through the decoder.
- `tests/LazyStringHeadTest.php` — both string types report their head across the 23/24 and 255/256 boundaries without being encoded first, the bytes are the same whichever observer runs first, repeated reads are stable, and a decoded string re-encodes to its original bytes.

905 tests pass (up from 871). `castor phpstan`, `ecs`, `rector`, `lint` and `deptrac` are clean, with no new baseline entry.
